### PR TITLE
fix 'fields' parse error in prospector.yml template.

### DIFF
--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -9,7 +9,7 @@ filebeat:
       <%- end %>
       <%- if @fields.length > 0 -%>
       fields:
-        <%- @fields.each do |k, v| -%>
+        <%- @fields.each_pair do |k, v| -%>
         <%= k %>: <%= v %>
         <%- end -%>
       <%- end -%>


### PR DESCRIPTION
This patch fixes the 'fields' parse error in template/prospector.yml.erb.
I tested the following pp creates proper yaml.

<test.pp>
...
filebeat::prospector { 'apache':
  paths => [
    '/var/log/httpd/*.log',
  ],
  log_type => 'apache',
  fields => {
    service => 'apache',
  },
}
...

</etc/filebeat/conf.d/cinder.yml>
filebeat:
  prospectors:
    - paths:
      - /var/log/httpd/*.log
      encoding: plain
      fields:
        service: apache
...
      document_type: apache
...