### PR TITLE
Change default file permissions.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class filebeat::config {
         content => template("${module_name}/filebeat.yml.erb"),
         owner   => 'root',
         group   => 'root',
-        mode    => '0644',
+        mode    => '0640',
         notify  => Service['filebeat'],
       }
 
@@ -28,7 +28,7 @@ class filebeat::config {
         path    => $filebeat::config_dir,
         owner   => 'root',
         group   => 'root',
-        mode    => '0755',
+        mode    => '0750',
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
       }

--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -24,7 +24,7 @@ define filebeat::prospector (
         path    => "${filebeat::config_dir}/${name}.yml",
         owner   => 'root',
         group   => 'root',
-        mode    => '0644',
+        mode    => '0640',
         content => template("${module_name}/prospector.yml.erb"),
         notify  => Service['filebeat'],
       }

--- a/spec/classes/filebeat_spec.rb
+++ b/spec/classes/filebeat_spec.rb
@@ -14,12 +14,12 @@ describe 'filebeat', :type => :class do
     it { is_expected.to contain_package('filebeat') }
     it { is_expected.to contain_file('filebeat.yml').with(
       :path => '/etc/filebeat/filebeat.yml',
-      :mode => '0644',
+      :mode => '0640',
     )}
     it { is_expected.to contain_file('filebeat-config-dir').with(
       :ensure => 'directory',
       :path   => '/etc/filebeat/conf.d',
-      :mode   => '0755',
+      :mode   => '0750',
       :recurse => true,
     )}
     it { is_expected.to contain_service('filebeat').with(

--- a/spec/defines/prospector_spec.rb
+++ b/spec/defines/prospector_spec.rb
@@ -27,7 +27,7 @@ describe 'filebeat::prospector', :type => :define do
 
       it { is_expected.to contain_file('filebeat-apache-logs').with(
         :path => '/apache-logs.yml',
-        :mode => '0644',
+        :mode => '0640',
         :content => 'filebeat:
   prospectors:
     - paths:


### PR DESCRIPTION
This changes the default perms in the configuration files in order to
preserve privacy and enhance security in a shared system. The files are
only readable by root.