### PR TITLE
replace contain with class{} to support puppet 2.7

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,14 @@
 class filebeat::install {
   case $::kernel {
     'Linux':   {
-      contain filebeat::install::linux
+      class { 'filebeat::install::linux': }
       if $::filebeat::manage_repo {
-        contain filebeat::repo
+        class { 'filebeat::repo': }
         Class['filebeat::repo'] -> Class['filebeat::install::linux']
       }
     }
     'Windows': {
-      contain filebeat::install::windows
+      class { 'filebeat::install::windows': }
     }
     default:   {
       fail($filebeat::kernel_fail_message)


### PR DESCRIPTION
Having a few EL6 machines stuck on old 2.7, I really wanted this.

I completely understand it if you don't want/need to support 2.7, in which case i'll just run the fork. However, the change is small and shouldn't break any existing functionality afaik.

