### PR TITLE
explicitly set service provider on redhat systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class filebeat (
   $manage_repo      = $filebeat::params::manage_repo,
   $service_ensure   = $filebeat::params::service_ensure,
   $service_enable   = $filebeat::params::service_enable,
+  $service_provider = $filebeat::params::service_provider,
   $spool_size       = $filebeat::params::spool_size,
   $idle_timeout     = $filebeat::params::idle_timeout,
   $registry_file    = $filebeat::params::registry_file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,13 +23,22 @@ class filebeat::params {
       $tmp_dir         = '/tmp'
       $install_dir     = undef
       $download_url    = undef
+      case $::osfamily {
+        'RedHat': {
+          $service_provider = 'redhat'
+        }
+        default: {
+          $service_provider = undef
+        }
+      }
     }
 
     'Windows' : {
-      $config_dir      = 'C:/Program Files/Filebeat/conf.d'
-      $download_url    = 'https://download.elastic.co/beats/filebeat/filebeat-1.0.1-windows.zip'
-      $install_dir     = 'C:/Program Files'
-      $tmp_dir         = 'C:/Temp'
+      $config_dir       = 'C:/Program Files/Filebeat/conf.d'
+      $download_url     = 'https://download.elastic.co/beats/filebeat/filebeat-1.0.1-windows.zip'
+      $install_dir      = 'C:/Program Files'
+      $tmp_dir          = 'C:/Temp'
+      $service_provider = undef
     }
 
     default : {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,7 @@
 class filebeat::service {
   service { 'filebeat':
-    ensure => $filebeat::service_ensure,
-    enable => $filebeat::service_enable,
+    ensure   => $filebeat::service_ensure,
+    enable   => $filebeat::service_enable,
+    provider => $filebeat::service_provider,
   }
 }


### PR DESCRIPTION
filebeat ships an init script, even on EL7 systems. puppet 4 cannot correctly check the status of init scripts through the EL7 systemd->init wrapper and thus attempts to start the service every time. While this doesn't actually try and start the service, the systemd wrapper is smart enough, it does cause an always changing scenario on every run.

Explicitly setting the provider to 'redhat' solves this and is safe even on older non-systemd redhat systems.