### PR TITLE
Use single quotes to fix include_line and exclude_line regex

### DIFF
--- a/spec/defines/prospector_spec.rb
+++ b/spec/defines/prospector_spec.rb
@@ -113,10 +113,10 @@ describe 'filebeat::prospector', :type => :define do
         negate: true
         match: after
       include_lines:
-        - "^ERROR"
-        - "^WARN"
+        - \'^ERROR\'
+        - \'^WARN\'
       exclude_lines:
-        - "^DEBUG"
+        - \'^DEBUG\'
 ',
       )}
     end

--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -76,12 +76,12 @@ filebeat:
       <%- if @include_lines.length > 0 -%>
       include_lines:
         <%- @include_lines.each do |include_line| -%>
-        - "<%= include_line %>"
+        - '<%= include_line %>'
         <%- end -%>
       <%- end -%>
       <%- if @exclude_lines.length > 0 -%>
       exclude_lines:
         <%- @exclude_lines.each do |exclude_line| -%>
-        - "<%= exclude_line %>"
+        - '<%= exclude_line %>'
         <%- end -%>
       <%- end -%>


### PR DESCRIPTION
Double quotes broke all of our prospector configurations. See: https://www.elastic.co/guide/en/beats/filebeat/1.2/regexp-support.html#regexp-support

```
We recommend that you wrap regular expressions in single quotation marks to work around YAML’s string escaping rules. For example, '^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'.```