### PR TITLE
Fix multiline pattern quotes

### DIFF
--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -58,7 +58,7 @@ filebeat:
       <%- if @multiline.length > 0 -%>
       multiline:
         <%- if @multiline['pattern'] -%>
-        pattern: <%= @multiline['pattern'] %>
+        pattern: '<%= @multiline['pattern'] %>'
         <%- end -%>
         <%- if @multiline['negate'] -%>
         negate: <%= @multiline['negate'] %>


### PR DESCRIPTION
According to documentation multiline pattern must be surrounded by quotes: https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html#multiline