### PR TITLE
Output logstash timeout value should be an integer.

### DIFF
--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -19,6 +19,9 @@
 <%- if @filebeat_config['output']['logstash']['port'] -%>
 <%- @filebeat_config['output']['logstash']['port'] = Integer(@filebeat_config['output']['logstash']['port']) -%>
 <%- end -%>
+<%- if @filebeat_config['output']['logstash']['timeout'] -%>
+<%- @filebeat_config['output']['logstash']['timeout'] = Integer(@filebeat_config['output']['logstash']['timeout']) -%>
+<%- end -%>
 <%- end -%>
 <%- if @filebeat_config['output']['redis'] -%>
 <%- if @filebeat_config['output']['redis']['port'] -%>


### PR DESCRIPTION
If this value is a string filebeat will not start

```
Loading config file error: YAML config parsing failed on /etc/filebeat/filebeat.yml: yaml: unmarshal errors:
  line 11: cannot unmarshal !!str `120` into int. Exiting.
```