### PR TITLE
Remove conditional logic

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -13,15 +13,6 @@ class filebeat::repo {
     'Debian': {
       include ::apt
 
-      # Install apt-transport-https if it's not already managed elsewhere
-      if !defined(Package['apt-transport-https']){
-        package { 'apt-transport-https':
-          ensure => present,
-          before => Class['apt::update'],
-        }
-      }
-      Class['apt::update'] -> Package['filebeat']
-
       if !defined(Apt::Source['beats']){
         apt::source { 'beats':
           location => $debian_repo_url,
@@ -33,6 +24,8 @@ class filebeat::repo {
           },
         }
       }
+
+      Exec['apt_update'] -> Package['filebeat']
     }
     'RedHat', 'Linux': {
       if !defined(Yumrepo['beats']){


### PR DESCRIPTION
After upgrading this module to version 0.8.0, Puppet is giving a dependency loop:

```
Error: Failed to apply catalog: Found 1 dependency cycle:
(Exec[apt_update] => Class[Apt::Update] => Package[apt-transport-https] => Class[Apt::Update] => Exec[apt_update])
```

I think what is happening here is that there is inconsistency between dependencies that are declared in the `filebeat` module with the following dependency that we declare ourselves:

```
Class['Apt::Update'] -> Package <| title != $::apt::ppa_package and title != 'python-configobj' |>
```

Another thing worth nothing here is that `defined` is not a reliable check in Puppet because it depends on the ordering of resources. For example, consider the following Puppet manifest:

```
notify { 'one': }

if (!defined(Notify['one'])) {
  notify { 'Notify[one] is not defined': }
}
if (!defined(Notify['two'])) {
  notify { 'Notify[two] is not defined': }
}

notify { 'two': }
```

This produces the following output (on Puppet 3.8.6):

```
Notice: Notify[two] is not defined
Notice: /Stage[main]/Main/Notify[Notify[two] is not defined]/message: defined 'message' as 'Notify[two] is not defined'
Notice: one
Notice: /Stage[main]/Main/Notify[one]/message: defined 'message' as 'one'
Notice: two
Notice: /Stage[main]/Main/Notify[two]/message: defined 'message' as 'two'
```

As such, I think that it is best to just remove the conditional logic and let the user manage these dependencies, if required.