### PR TITLE
Fix setting for `max_procs`

### DIFF
--- a/templates/filebeat5.yml.erb
+++ b/templates/filebeat5.yml.erb
@@ -31,7 +31,7 @@ queue_size: <%= @filebeat_config['queue_size'] %>
 # Do not modify this value.
 #bulk_queue_size: 0
 
-<%- if @filebeat_config['max_procs'] != nil -%>
+<%- if @filebeat_config['max_procs'] != :undef -%>
 max_procs: <%= @filebeat_config['max_procs'] %>
 <%- end -%>
 


### PR DESCRIPTION
After updating this module to version 0.8.0, I ran into the following error:

```
Error: Could not start Service[filebeat]: Execution of '/etc/init.d/filebeat start' returned 1: Exiting: error unpacking config data: can not convert 'string' into 'int' accessing 'max_procs' (source:'/etc/filebeat/filebeat.yml')
   ...fail!
Error: /Stage[main]/Filebeat::Service/Service[filebeat]/ensure: change from stopped to running failed: Could not start Service[filebeat]: Execution of '/etc/init.d/filebeat start' returned 1: Exiting: error unpacking config data: can not convert 'string' into 'int' accessing 'max_procs' (source:'/etc/filebeat/filebeat.yml')
   ...fail!
```

Basically, the problem is that `/etc/filebeat/filebeat.yml` contained the following:

```
max_procs: undef
```