### PR TITLE
Fix document type for Filebeat 5

### DIFF
--- a/templates/prospector5.yml.erb
+++ b/templates/prospector5.yml.erb
@@ -37,8 +37,8 @@ filebeat:
       <%- if @ignore_older -%>
       ignore_older: <%= @ignore_older %>
       <%- end -%>
-      <%- if @real_doc_type -%>
-      document_type: <%= @real_doc_type %>
+      <%- if @doc_type -%>
+      document_type: <%= @doc_type %>
       <%- end -%>
       <%- if @scan_frequency -%>
       scan_frequency: <%= @scan_frequency %>


### PR DESCRIPTION
Setting a `document_type` with Filebeat 5 is currently completely broken.