### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,7 +59,7 @@ class filebeat::params {
     }
 
     default : {
-      fail($filebeat::kernel_fail_message)
+      fail("${::kernel} is not supported by filebeat.")
     }
   }
 }


### PR DESCRIPTION
$kernel_fail_message is not defined yet, so it gives the following error when you try to use the module in FreeBSD:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call,  at /etc/puppetlabs/puppet/thirdparty_modules/filebeat/manifests/params.pp:62:7 on node freebsd103.puppet.local