### PR TITLE
Fix error when max_procs is empty

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 class filebeat::config {
-  $filebeat_config = {
+  $filebeat_config = delete_undef_values({
     'shutdown_timeout'  => $filebeat::shutdown_timeout,
     'beat_name'         => $filebeat::beat_name,
     'tags'              => $filebeat::tags,
@@ -19,7 +19,7 @@ class filebeat::config {
     'shipper'           => $filebeat::shipper,
     'logging'           => $filebeat::logging,
     'runoptions'        => $filebeat::run_options,
-  }
+  })
 
   case $::kernel {
     'Linux'   : {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,8 @@ class filebeat (
   $prospectors_merge    = false,
 ) inherits filebeat::params {
 
+  include stdlib
+
   $kernel_fail_message = "${::kernel} is not supported by filebeat."
 
   validate_bool($manage_repo, $prospectors_merge)

--- a/spec/acceptance/001_basic_spec.rb
+++ b/spec/acceptance/001_basic_spec.rb
@@ -69,5 +69,11 @@ describe "filebeat class" do
     describe package(package_name) do
       it { should be_installed }
     end
+
+    describe file('/etc/filebeat/filebeat.yml') do
+      it { should be_file }
+      it { should contain('---') }
+      it { should_not contain('max_procs: !ruby') }
+    end
   end
 end

--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -1,4 +1,3 @@
-<%- filebeat_config = @filebeat_config.delete_if { |key, value| !defined?(value) } -%>
 <%- @filebeat_config['filebeat']['spool_size'] = Integer(@filebeat_config['filebeat']['spool_size']) -%>
 <%- if @filebeat_config['output']['file'] -%>
 <%- if @filebeat_config['output']['file']['rotate_every_kb'] -%>


### PR DESCRIPTION
Fix an error when max_procs beeing undef leading to: 

```
### Filebeat configuration managed by Puppet ###
---
...
  max_procs: !ruby/sym undef
```