### PR TITLE
Adding Support for Filebeat Processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,58 @@ When installing on Windows, this module will download the windows version of Fil
 can be overridden using the `tmp_dir` parameter. `tmp_dir` is not managed by this module,
 but is expected to exist as a directory that puppet can write to.
 
+### Processors
+
+Filebeat 5.0 and greater includes a new libbeat feature for filtering and/or enhancing all
+exported data through processors before geing sent to the configured output(s). By populating
+the `processors` parameter any number of processors may be configured to work on all events
+or only those that match certain conditions.
+
+To drop the offset and input_type fields from all events:
+
+```puppet
+class{"filebeat":
+  processors => [
+    {
+      "name" => "drop_fields",
+      "params" => ["input_type", "offset"]
+    },
+  ],
+}
+```
+
+To drop all events that have the http response code equal to 200:
+
+```puppet
+class{"filebeat":
+  processors => [
+    {
+      "name" => "drop_event",
+      "when" => {"equals" => {"http.code" => 200}}
+    },
+  ],
+}
+```
+
+Now to combine these examples into a single definition:
+
+```puppet
+class{"filebeat":
+  processors => [
+    {
+      "name" => "drop_fields",
+      "params" => ["input_type", "offset"]
+    },
+    {
+      "name" => "drop_event",
+      "when" => {"equals" => {"http.code" => 200}}
+    },
+  ],
+}
+```
+
+For more information please review the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/5.1/configuration-processors.html).
+
 ## Reference
  - [**Public Classes**](#public-classes)
     - [Class: filebeat](#class-filebeat)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,7 @@ class filebeat::config {
     'shipper'           => $filebeat::shipper,
     'logging'           => $filebeat::logging,
     'runoptions'        => $filebeat::run_options,
+    'processors'        => $filebeat::processors,
   })
 
   case $::kernel {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 # @param max_procs [Number] The maximum number of CPUs that can be simultaneously used
 # @param fields [Hash] Optional fields that should be added to each event output
 # @param fields_under_root [Boolean] If set to true, custom fields are stored in the top level instead of under fields
+# @param processors [Array] An optional list of hashes used to configure filebeat processors
 # @param prospectors [Hash] Prospectors that will be created. Commonly used to create prospectors using hiera
 # @param prospectors_merge [Boolean] Whether $prospectors should merge all hiera sources, or use simple automatic parameter lookup
 class filebeat (
@@ -77,6 +78,7 @@ class filebeat (
   $max_procs            = $filebeat::params::max_procs,
   $fields               = $filebeat::params::fields,
   $fields_under_root    = $filebeat::params::fields_under_root,
+  $processors           = $filebeat::params::processors,
   #### End v5 onlly ####
   $prospectors          = {},
   $prospectors_merge    = false,
@@ -125,6 +127,7 @@ class filebeat (
     warning('You\'ve specified a non-standard config_file location - filebeat may fail to start unless you\'re doing something to fix this')
   }
 
+  validate_array($processors)
   validate_hash($outputs, $logging, $prospectors_final)
   validate_string($idle_timeout, $registry_file, $config_dir, $package_ensure)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class filebeat::params {
   $logging        = {}
   $run_options    = {}
   $use_generic_template = false
+  $processors           = []
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {

--- a/templates/filebeat5.yml.erb
+++ b/templates/filebeat5.yml.erb
@@ -1,3 +1,16 @@
+<%-
+  def yaml_indent(conds, idx=4)
+    return_val = []
+    tmp_val = conds.to_yaml.split("\n")
+    tmp_val.delete('---')
+
+    tmp_val.each do |val|
+      return_val << "    " + val
+    end
+
+    return_val.join("\n")
+  end
+-%>
 #========================= Filebeat global options ============================
 
 filebeat.spool_size: <%= @filebeat_config['filebeat']['spool_size'] %>
@@ -63,6 +76,19 @@ max_procs: <%= @filebeat_config['max_procs'] %>
 #       equals:
 #           http.code: 200
 #
+<%- unless @filebeat_config['processors'].empty? -%>
+processors:
+  <%- @filebeat_config['processors'].each do |_proc| -%>
+- <%= _proc['name'] %>:
+    <%- unless _proc['when'].nil? or _proc['when'].empty? -%>
+  when:
+<%=  yaml_indent(_proc['when']) %>
+    <%- end -%>
+    <%- _proc['params'].each do |key,val|-%>
+  <%= key %>: <%= val %>
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
 
 #================================ Outputs =====================================
 


### PR DESCRIPTION
Adds the functionality to configure processors through Puppet parameters, this includes README updates describing the functionality.

Example, in order to create the following processor structure users can define them using the proceeding definition

```yaml
processors:
- include_fields:
    fields: ["cpu"]
- drop_fields:
    fields: ["cpu.user", "cpu.system"]
- drop_event:
    when:
       equals:
           http.code: 200
```

```puppet
class{"filebeat":
  processors => [
    {
      "name" => "include_fields",
      "params" => {"fields" => ["cpu"]}
    },
    {
      "name" => "drop_fields",
      "params" => {"fields" => ["cpu.user", "cpu.system"]}
    },
    {
      "name" => "drop_event",
      "when" => {"equals" => {"http.code" => 200}}
    },
  ],
}
```