### PR TITLE
support harvesting symlinks

### DIFF
--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -29,11 +29,12 @@ define filebeat::prospector (
   $multiline             = {},
   $json                  = {},
   $tags                  = [],
+  $symlinks              = false,
 ) {
 
   validate_hash($fields, $multiline, $json)
   validate_array($paths, $exclude_files, $include_lines, $exclude_lines, $tags)
-  validate_bool($tail_files, $close_renamed, $close_removed, $close_eof, $clean_removed)
+  validate_bool($tail_files, $close_renamed, $close_removed, $close_eof, $clean_removed, $symlinks)
 
   $prospector_template = $filebeat::real_version ? {
     '1'     => 'prospector1.yml.erb',

--- a/templates/prospector5.yml.erb
+++ b/templates/prospector5.yml.erb
@@ -55,6 +55,9 @@ filebeat:
       <%- if @max_bytes -%>
       max_bytes: <%= @max_bytes %>
       <%- end -%>
+      <%- if @symlinks -%>
+      symlinks: <%= @symlinks %>
+      <%- end -%>
 
       <%- if @json.length > 0 -%>
       ### JSON configuration


### PR DESCRIPTION
Allow filebeat to harvest symlinks without dereferencing.

Specific use case is to use kubernetes symlinked logfile names to tag stuff with once it reaches logstash. 