### PR TITLE
Fix yaml parser issue for processors

### DIFF
--- a/templates/filebeat5.yml.erb
+++ b/templates/filebeat5.yml.erb
@@ -2,10 +2,10 @@
   def yaml_indent(conds)
     return_val = []
     tmp_val = conds.to_yaml.split("\n")
-    tmp_val.delete('---')
+    tmp_val.delete_if { |x| x.include?("---") }
 
     tmp_val.each do |val|
-      return_val << "        " + val
+      return_val << "      " + val
     end
 
     return_val.join("\n")


### PR DESCRIPTION
--- in filebeat.yml used to break the filebeat service.
This fix would remove this line and realign the remaining drop_event data
in yaml format

