### PR TITLE
Reworking the processor implementation.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@
 # @param max_procs [Number] The maximum number of CPUs that can be simultaneously used
 # @param fields [Hash] Optional fields that should be added to each event output
 # @param fields_under_root [Boolean] If set to true, custom fields are stored in the top level instead of under fields
-# @param processors [Array] An optional list of hashes used to configure filebeat processors
+# @param processors [Hash] Processors that will be added. Commonly used to create processors using hiera.
 # @param prospectors [Hash] Prospectors that will be created. Commonly used to create prospectors using hiera
 # @param prospectors_merge [Boolean] Whether $prospectors should merge all hiera sources, or use simple automatic parameter lookup
 class filebeat (
@@ -78,7 +78,8 @@ class filebeat (
   $max_procs            = $filebeat::params::max_procs,
   $fields               = $filebeat::params::fields,
   $fields_under_root    = $filebeat::params::fields_under_root,
-  $processors           = $filebeat::params::processors,
+  $processors           = {},
+  $processors_merge     = false,
   #### End v5 onlly ####
   $prospectors          = {},
   $prospectors_merge    = false,
@@ -88,7 +89,7 @@ class filebeat (
 
   $kernel_fail_message = "${::kernel} is not supported by filebeat."
 
-  validate_bool($manage_repo, $prospectors_merge)
+  validate_bool($manage_repo, $processors_merge, $prospectors_merge)
 
   if $major_version == undef and $::filebeat_version == undef {
     $real_version = '5'
@@ -123,11 +124,16 @@ class filebeat (
     $prospectors_final = $prospectors
   }
 
+  if $processors_merge {
+    $processors_final = hiera_hash('filebeat::processors', $processors)
+  } else {
+    $processors_final = $processors
+  }
+
   if $config_file != $filebeat::params::config_file {
     warning('You\'ve specified a non-standard config_file location - filebeat may fail to start unless you\'re doing something to fix this')
   }
 
-  validate_array($processors)
   validate_hash($outputs, $logging, $prospectors_final)
   validate_string($idle_timeout, $registry_file, $config_dir, $package_ensure)
 
@@ -143,5 +149,8 @@ class filebeat (
 
   if !empty($prospectors_final) {
     create_resources('filebeat::prospector', $prospectors_final)
+  }
+  if !empty($processors_final) {
+    create_resources('filebeat::processors', $processors_final)
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class filebeat::params {
   $logging              = {}
   $run_options          = {}
   $use_generic_template = false
-  $processors           = []
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {

--- a/manifests/processor.pp
+++ b/manifests/processor.pp
@@ -1,0 +1,74 @@
+define filebeat::processor(
+  $ensure         = present,
+  $priority       = 10,
+  $processor_name = $name,
+  $params         = undef,
+  $when           = undef,
+) {
+  include ::filebeat
+
+  validate_integer($priority)
+  validate_string($processor_name)
+
+  if versioncmp("${filebeat::real_version}", '5') < 0 {
+    fail("Processors only work on Filebeat 5.0 and higher")
+  }
+
+  if $priority < 10 {
+    $_priority = "0${priority}"
+  }
+  else {
+    $_priority = "${priority}"
+  }
+
+  if $processor_name == "drop_field" and $when == undef {
+    fail("drop_event processors require a condition, without one ALL events are dropped")
+  }
+  elsif $processor_name != 'add_cloud_metadata' and $params == undef {
+    fail("${processor_name} requires parameters to function as expected")
+  }
+
+  if $processor_name == 'add_cloud_metadata' {
+    $_configuration = delete_undef_values(merge({"timeout" => "3s"}, $params))
+  }
+  elsif $processor_name == 'drop_field' {
+    $_configuration = $when
+  }
+  else {
+    $_configuration = delete_undef_values(merge({"when" => $when}, $params))
+  }
+
+  $filename         = "${filebeat::config_dir}/${_priority}-processor-${name}.yml"
+  $processor_config = delete_undef_values({
+    "processors" => [
+      {
+        $processor_name => $_configuration,
+      }
+    ]
+  })
+
+  case $::kernel {
+    'Linux': {
+      file{"${filename}":
+        ensure       => $ensure,
+        owner        => 'root',
+        group        => 'root',
+        mode         => $::filebeat::config_file_mode,
+        content      => inline_template("<%= @processor_config.to_yaml() %>"),
+        validate_cmd => "/usr/share/filebeat/bin/filebeat -N -configtest -c %",
+        notify       => Class["filebeat::service"],
+      }
+    }
+    'Windows': {
+      file{"${filename}":
+        ensure       => $ensure,
+        content      => inline_template("<%= @processor_config.to_yaml() %>"),
+        validate_cmd => "c:\\Program Files\\Filebeat\\filebeat.exe -N -configtest -c %",
+        notify       => Class["filebeat::service"],
+      }
+    }
+    default: {
+      fail($filebeat::kernel_fail_message)
+    }
+  }
+}

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+describe 'filebeat::processor', type: :define do
+  let :pre_condition do
+    'class{"filebeat":
+      outputs => {
+        "logstash" => {
+          "hosts" => [
+            "localhost:5044",
+          ],
+        },
+      },
+    }'
+  end
+  let :title do
+    'test-processor'
+  end
+
+  context 'with no parameters' do
+    it { is_expected.to raise_error(Puppet::Error) }
+  end
+
+  context 'on Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'Linux',
+        rubyversion: '2.3.1',
+        filebeat_version: '5.1.2'
+      }
+    end
+
+    context 'add_cloud_metadata processor' do
+      let :params do
+        {
+          processor_name: 'add_cloud_metadata',
+        }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+          mode: '0644',
+          content: '---
+processors:
+- add_cloud_metadata:
+    timeout: 3s
+'
+        )
+      end
+    end
+
+    context 'drop_event processor with no conditions' do
+      let :params do
+        {
+          processor_name: 'drop_event'
+        }
+      end
+
+      it { is_expected.to raise_error(Puppet::Error) }
+    end
+
+    context 'drop_event processor with conditions' do
+      let :params do
+        {
+          processor_name: 'drop_event',
+          when: {regex: {message: '^DEBUG'}}
+        }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+          mode: '0644',
+          content: '---
+processors:
+- drop_event:
+    when:
+      regex:
+        message: ^DEBUG
+'
+        )
+      end
+    end
+
+    context 'drop_field processor with no params' do
+      let :params do
+        {
+          processor_name: 'drop_field'
+        }
+      end
+
+      it { is_expected.to raise_error(Puppet::Error) }
+    end
+
+    context 'drop_field processor with fields' do
+      let :params do
+        {
+          processor_name: 'drop_field',
+          params: {fields: ['input_type', 'offset']}
+        }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+          mode: '0644',
+          content: '---
+processors:
+- drop_field:
+    fields:
+      - input_type
+      - offset
+'
+        )
+      end
+    end
+  end
+end

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -33,7 +33,7 @@ describe 'filebeat::processor', type: :define do
     context 'add_cloud_metadata processor' do
       let :params do
         {
-          processor_name: 'add_cloud_metadata',
+          processor_name: 'add_cloud_metadata'
         }
       end
 

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -38,8 +38,9 @@ describe 'filebeat::processor', type: :define do
       end
 
       it do
-        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+        is_expected.to contain_file('filebeat-processor-test-processor').with(
           mode: '0644',
+          path: '/etc/filebeat/conf.d/10-processor-test-processor.yml',
           content: '---
 processors:
 - add_cloud_metadata:
@@ -68,8 +69,9 @@ processors:
       end
 
       it do
-        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+        is_expected.to contain_file('filebeat-processor-test-processor').with(
           mode: '0644',
+          path: '/etc/filebeat/conf.d/10-processor-test-processor.yml',
           content: '---
 processors:
 - drop_event:
@@ -100,8 +102,9 @@ processors:
       end
 
       it do
-        is_expected.to contain_file('/etc/filebeat/conf.d/10-processor-test-processor.yml').with(
+        is_expected.to contain_file('filebeat-processor-test-processor').with(
           mode: '0644',
+          path: '/etc/filebeat/conf.d/10-processor-test-processor.yml',
           content: '---
 processors:
 - drop_field:

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -60,29 +60,6 @@ processors:
       it { is_expected.to raise_error(Puppet::Error) }
     end
 
-    context 'drop_event processor with conditions' do
-      let :params do
-        {
-          processor_name: 'drop_event',
-          when: {regex: {message: '^DEBUG'}}
-        }
-      end
-
-      it do
-        is_expected.to contain_file('filebeat-processor-test-processor').with(
-          mode: '0644',
-          path: '/etc/filebeat/conf.d/10-processor-test-processor.yml',
-          content: '---
-processors:
-- drop_event:
-    when:
-      regex:
-        message: ^DEBUG
-'
-        )
-      end
-    end
-
     context 'drop_field processor with no params' do
       let :params do
         {
@@ -91,29 +68,6 @@ processors:
       end
 
       it { is_expected.to raise_error(Puppet::Error) }
-    end
-
-    context 'drop_field processor with fields' do
-      let :params do
-        {
-          processor_name: 'drop_field',
-          params: {fields: ['input_type', 'offset']}
-        }
-      end
-
-      it do
-        is_expected.to contain_file('filebeat-processor-test-processor').with(
-          mode: '0644',
-          path: '/etc/filebeat/conf.d/10-processor-test-processor.yml',
-          content: '---
-processors:
-- drop_field:
-    fields:
-      - input_type
-      - offset
-'
-        )
-      end
     end
   end
 end

--- a/templates/filebeat5.yml.erb
+++ b/templates/filebeat5.yml.erb
@@ -1,16 +1,3 @@
-<%-
-  def yaml_indent(conds)
-    return_val = []
-    tmp_val = conds.to_yaml.split("\n")
-    tmp_val.delete('---')
-
-    tmp_val.each do |val|
-      return_val << "        " + val
-    end
-
-    return_val.join("\n")
-  end
--%>
 #========================= Filebeat global options ============================
 
 filebeat.spool_size: <%= @filebeat_config['filebeat']['spool_size'] %>
@@ -76,21 +63,6 @@ max_procs: <%= @filebeat_config['max_procs'] %>
 #       equals:
 #           http.code: 200
 #
-<%- unless @filebeat_config['processors'].empty? -%>
-processors:
-  <%- @filebeat_config['processors'].each do |_proc| -%>
-  - <%= _proc['name'] %>:
-    <%- unless _proc['when'].nil? or _proc['when'].empty? -%>
-      when:
-<%=  yaml_indent(_proc['when']) %>
-    <%- end -%>
-    <%- unless _proc['params'].nil? or _proc['params'].empty? -%>
-    <%- _proc['params'].each do |key,val|-%>
-      <%= key %>: <%= val %>
-    <%- end -%>
-    <%- end -%>
-  <%- end -%>
-<%- end -%>
 
 #================================ Outputs =====================================
 


### PR DESCRIPTION
Instead of, what can become, a complicated original implementation migrating
filebeat processors to it's own defined type. There it's much easier to perform
some value checking before generating the configuration files in the config
dir location.

Orignally processors can only be declared using a class parameter like the following example

`
class{"filebeat":
  processors => [
    {
      "drop_fields" => {
        "params" => {"fields" => ["input_type", "offset"]}
      }
    }
  ]
}`

Now they can be declared using defined type `filebeat::processor`, or still through $filebeat::processors but with a breaking format. Examples:

`
class{"filebeat":
  processors => {
    "my_processor" => {
      "processor_name" => "drop_fields",
      "params" => {"fields" => ["input_type", "offset"]}
    }
  }
}
`

`
filebeat::processor{"my_processor":
  processor_name => "drop_fields",
  params => {"fields" => ["input_type", "offset"]}
}
`

Have had issues with rake testing on my development environment which I cannot figure out. Travis CI testing may or may not be successful with the new test cases.