### PR TITLE
Removing validate_cmd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,6 @@ class filebeat::config {
         owner        => 'root',
         group        => 'root',
         mode         => $filebeat::config_file_mode,
-        validate_cmd => "${filebeat_path} -N -configtest -c %",
         notify       => Service['filebeat'],
         require      => File['filebeat-config-dir'],
       }
@@ -62,7 +61,6 @@ class filebeat::config {
         ensure       => file,
         path         => $filebeat::config_file,
         content      => template($filebeat::real_conf_template),
-        validate_cmd => "\"${filebeat_path}\" -N -configtest -c \"%\"",
         notify       => Service['filebeat'],
         require      => File['filebeat-config-dir'],
       }

--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -55,7 +55,6 @@ define filebeat::prospector (
         group        => 'root',
         mode         => $::filebeat::config_file_mode,
         content      => template("${module_name}/${prospector_template}"),
-        validate_cmd => "${filebeat_path} -N -configtest -c %",
         notify       => Service['filebeat'],
       }
     }
@@ -66,7 +65,6 @@ define filebeat::prospector (
         ensure       => $ensure,
         path         => "${filebeat::config_dir}/${name}.yml",
         content      => template("${module_name}/${prospector_template}"),
-        validate_cmd => "\"${filebeat_path}\" -N -configtest -c \"%\"",
         notify       => Service['filebeat'],
       }
     }


### PR DESCRIPTION
It removes the `validate_cmd` command to work with Puppet < 3.4.x