### PR TITLE
Revert change to confine in filebeat_version

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -1,6 +1,6 @@
 require 'facter'
 Facter.add('filebeat_version') do
-  confine kernel: %w(Linux Windows)
+  confine :kernel => %w(Linux Windows)
   if File.executable?('/usr/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat --version')
   elsif File.executable?('/usr/share/filebeat/bin/filebeat')


### PR DESCRIPTION
The change in e5ebb2e breaks with the following error:
```
Error loading fact /var/lib/puppet/lib/facter/filebeat_version.rb: /var/lib/puppet/lib/facter/filebeat_version.rb:3: syntax error,
 unexpected ':', expecting kEND
  confine kernel: %w(Linux Windows)
                 ^
Error loading fact /var/lib/puppet/lib/facter/filebeat_version.rb: /var/lib/puppet/lib/facter/filebeat_version.rb:3: syntax error,
 unexpected ':', expecting kEND
  confine kernel: %w(Linux Windows)
```

on my machine with ruby 1.8.7, puppet 3.8.7, and facter 2.4.6. By reverting to the previous syntax, it works again. Everything else in the module appears to be compatible with the versions I have installed.