### PR TITLE
processor: Checking for the drop_event processor instead of the drop_field

### DIFF
--- a/manifests/processor.pp
+++ b/manifests/processor.pp
@@ -21,7 +21,7 @@ define filebeat::processor(
     $_priority = $priority
   }
 
-  if $processor_name == 'drop_field' and $when == undef {
+  if $processor_name == 'drop_event' and $when == undef {
     fail('drop_event processors require a condition, without one ALL events are dropped')
   }
   elsif $processor_name != 'add_cloud_metadata' and $params == undef {
@@ -31,7 +31,7 @@ define filebeat::processor(
   if $processor_name == 'add_cloud_metadata' {
     $_configuration = delete_undef_values(merge({'timeout' => '3s'}, $params))
   }
-  elsif $processor_name == 'drop_field' {
+  elsif $processor_name == 'drop_event' {
     $_configuration = $when
   }
   else {


### PR DESCRIPTION
We want to error when drop_event is used.

Don't know how this got missed. This commit fixes a bug where if a user uses the drop_event processor without any configuration options Puppet would not throw errors, it would still happen at the filebeat level. Now it errors at the puppet level.