### PR TITLE
support kafka codec.format option

### DIFF
--- a/templates/filebeat5.yml.erb
+++ b/templates/filebeat5.yml.erb
@@ -300,6 +300,12 @@ output.kafka:
   <%- if @filebeat_config['output']['kafka']['key'] != nil -%>
   key: '<%= @filebeat_config['output']['kafka']['key'] %>'
   <%- end -%>
+  <%- if @filebeat_config['output']['kafka']['codec.format'] != nil -%>
+  codec.format:
+    <%- if @filebeat_config['output']['kafka']['codec.format']['string'] != nil -%>
+    string: <%= @filebeat_config['output']['kafka']['codec.format']['string'] %>
+    <%- end -%>
+  <%- end -%>
   <%- if @filebeat_config['output']['kafka']['partition'] != nil and @filebeat_config['output']['kafka']['partition']['hash'] != nil -%>
   partition.hash:
     <%- if @filebeat_config['output']['kafka']['partition']['hash']['reachable_only'] != nil -%>


### PR DESCRIPTION
necessary when shipping 'raw' log lines is desired (e.g. logs are already
in logstash compatible json)