### PR TITLE
install locales on ubuntu-16.04 nodeset

### DIFF
--- a/spec/acceptance/nodesets/ubuntu-16.04.yml
+++ b/spec/acceptance/nodesets/ubuntu-16.04.yml
@@ -9,7 +9,7 @@ HOSTS:
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
-      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget locales && locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200
   type: foss


### PR DESCRIPTION
this makes the 16.04 tests pass

this is the error it's getting while building the docker image:
```
Step 10 : RUN rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8
 ---> Running in b2bb58c12ecc
Removing 'local diversion of /sbin/initctl to /sbin/initctl.distrib'
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
wget is already the newest version (1.17.1-1ubuntu1.2).
wget set to manually installed.
The following NEW packages will be installed:
  net-tools
0 upgraded, 1 newly installed, 0 to remove and 3 not upgraded.
Need to get 175 kB of archives.
After this operation, 725 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 net-tools amd64 1.60-26ubuntu1 [175 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 175 kB in 0s (195 kB/s)
Selecting previously unselected package net-tools.
(Reading database ... 9851 files and directories currently installed.)
Preparing to unpack .../net-tools_1.60-26ubuntu1_amd64.deb ...
Unpacking net-tools (1.60-26ubuntu1) ...
Setting up net-tools (1.60-26ubuntu1) ...
/bin/sh: 1: locale-gen: not found
The command '/bin/sh -c rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8' returned a non-zero code: 127
```