### PR TITLE
Adding support for pipeline configuration in prospectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ to fully understand what these parameters do.
   - `backoff_factor`: [Integer] `backoff` is multiplied by this parameter until `max_backoff` is reached to
     determine the actual backoff (default: 2)
   - `force_close_files`: [Boolean] Should filebeat forcibly close a file when renamed (default: false)
+  - `pipeline`: [String] Filebeat can be configured for a different ingest pipeline for each prospector (default: undef)
   - `include_lines`: [Array] A list of regular expressions to match the lines that you want to include.
     Ignored if empty (default: [])
   - `exclude_lines`: [Array] A list of regular expressions to match the files that you want to exclude.

--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -30,6 +30,7 @@ define filebeat::prospector (
   $json                  = {},
   $tags                  = [],
   $symlinks              = false,
+  $pipeline              = undef,
 ) {
 
   validate_hash($fields, $multiline, $json)

--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -64,6 +64,9 @@ filebeat:
       <%- if @force_close_files -%>
       force_close_files: <%= @force_close_files %>
       <%- end -%>
+      <%- if @pipeline -%>
+      pipeline: <%= @pipeline %>
+      <%- end -%>
 
       <%- if @json.length > 0 -%>
       ### JSON configuration


### PR DESCRIPTION
Pipelines can be configured per prospector instead of only for the whole filebeat.  I'm adding this config in here so this can be supported.