### PR TITLE
Support for hash.random

### DIFF
--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -320,6 +320,9 @@ output.kafka:
     <%- if @filebeat_config['output']['kafka']['partition']['hash']['reachable_only'] != nil -%>
     reachable_only: <%= @filebeat_config['output']['kafka']['partition']['hash']['reachable_only'] %>
     <%- end -%>
+    <%- if @filebeat_config['output']['kafka']['partition']['hash']['random'] != nil -%>
+    random: <%= @filebeat_config['output']['kafka']['partition']['hash']['random'] %>
+    <%- end -%>
     <%- if @filebeat_config['output']['kafka']['partition']['hash']['hash'] != nil -%>
     hash:
     <%- @filebeat_config['output']['kafka']['partition']['hash']['hash'].each do |value| -%>


### PR DESCRIPTION
Add Support for hash.random
hash.random: Randomly distribute events if no hash or key value can be computed.

https://www.elastic.co/guide/en/beats/filebeat/master/kafka-output.html

@pcfens when do you think you're going to build a new version with this change ?
