### PR TITLE
Processors should be an Array of Hashes !

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 # @param max_procs [Integer] The maximum number of CPUs that can be simultaneously used
 # @param fields [Hash] Optional fields that should be added to each event output
 # @param fields_under_root [Boolean] If set to true, custom fields are stored in the top level instead of under fields
-# @param processors [Hash] Processors that will be added. Commonly used to create processors using hiera.
+# @param processors [Array] Processors that will be added. Commonly used to create processors using hiera.
 # @param prospectors [Hash] Prospectors that will be created. Commonly used to create prospectors using hiera
 # @param setup [Hash] setup that will be created. Commonly used to create setup using hiera
 # @param prospectors_merge [Boolean] Whether $prospectors should merge all hiera sources, or use simple automatic parameter lookup
@@ -82,7 +82,7 @@ class filebeat (
   Hash $fields                                                                                                                               = $filebeat::params::fields,
   Boolean $fields_under_root                                                                                                                 = $filebeat::params::fields_under_root,
   Boolean $disable_config_test                                                                                                               = $filebeat::params::disable_config_test,
-  Hash    $processors                                                                                                                        = {},
+  Array   $processors                                                                                                                        = [],
   Hash    $prospectors                                                                                                                       = {},
   Hash    $setup                                                                                                                             = {},
   Optional[Pattern[/^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-\.]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\ = [\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$/]] $proxy_address = undef, # lint:ignore:140chars


### PR DESCRIPTION
See https://github.com/pcfens/puppet-filebeat/issues/156

Using Array the processors configuration works (tested).