### PR TITLE
fix array validation

### DIFF
--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -39,7 +39,7 @@ define filebeat::prospector (
   Array[String] $tags               = [],
   Boolean $symlinks                 = false,
   Optional[String] $pipeline        = undef,
-  Array[String] $processors         = [],
+  Array $processors                 = [],
 ) {
 
   $prospector_template = $filebeat::major_version ? {


### PR DESCRIPTION
Change to https://github.com/pcfens/puppet-filebeat/blob/master/manifests/prospector.pp#L42
led to the following error due to processors might be array of hashes:
Evaluation Error: Error while evaluating a Resource Statement, Filebeat::Prospector[docker]: parameter 'processors' index 0 expects a String value, got Struct at /etc/puppetlabs/code/environments/filebeat_processor/modules/filebeat/manifests/init.pp:133 on node

