### PR TITLE
Windows fix

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -9,6 +9,8 @@ Facter.add('filebeat_version') do
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/sbin/filebeat --version')
   elsif File.exist?('c:\Program Files\Filebeat\filebeat.exe')
     filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
+  elsif (filebeat_dir = Dir.glob('c:/ProgramData/chocolatey/lib/filebeat/tools/filebeat-*')[0])
+    filebeat_version = Facter::Util::Resolution.exec('"' + filebeat_dir + '/filebeat.exe" --version')
   end
   setcode do
     %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1] unless filebeat_version.nil?

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -139,7 +139,7 @@ class filebeat::config {
 
     'Windows' : {
       $cmd_install_dir = regsubst($filebeat::install_dir, '/', '\\', 'G')
-      $filebeat_path = join([$cmd_install_dir, 'Filebeat', 'filebeat.exe'], '\\')
+      $filebeat_path = join([$cmd_install_dir, 'filebeat.exe'], '\\')
 
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -5,78 +5,8 @@
 # @summary A private class that installs filebeat on Windows
 #
 class filebeat::install::windows {
-  # I'd like to use chocolatey to do this install, but the package for chocolatey is
-  # failing for updates and seems rather unpredictable at the moment. We may revisit
-  # that in the future as it would greatly simplify this code and basically reduce it to
-  # one package resource with type => chocolatey....
-
-  $filename = regsubst($filebeat::real_download_url, '^https?.*\/([^\/]+)\.[^.].*', '\1')
-  $foldername = 'Filebeat'
-  $zip_file = join([$filebeat::tmp_dir, "${filename}.zip"], '/')
-  $install_folder = join([$filebeat::install_dir, $foldername], '/')
-  $version_file = join([$install_folder, $filename], '/')
-
-  Exec {
-    provider => powershell,
-  }
-
-  if ! defined(File[$filebeat::install_dir]) {
-    file { $filebeat::install_dir:
-      ensure => directory,
-    }
-  }
-
-  # Note: We can use archive for unzip and cleanup, thus removing the following two resources.
-  # However, this requires 7zip, which archive can install via chocolatey:
-  # https://github.com/voxpupuli/puppet-archive/blob/master/manifests/init.pp#L31
-  # I'm not choosing to impose those dependencies on anyone at this time...
-  archive { $zip_file:
-    source       => $filebeat::real_download_url,
-    cleanup      => false,
-    creates      => $version_file,
-    proxy_server => $filebeat::proxy_address,
-  }
-
-  exec { "unzip ${filename}":
-    command => "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path '${filebeat::install_dir}')).Copyhere(\$sh.namespace((Convert-Path '${zip_file}')).items(), 16)", # lint:ignore:140chars
-    creates => $version_file,
-    require => [
-      File[$filebeat::install_dir],
-      Archive[$zip_file],
-    ],
-  }
-
-  # Clean up after ourselves
-  file { $zip_file:
-    ensure  => absent,
-    backup  => false,
-    require => Exec["unzip ${filename}"],
-  }
-
-  # You can't remove the old dir while the service has files locked...
-  exec { "stop service ${filename}":
-    command => 'Set-Service -Name filebeat -Status Stopped',
-    creates => $version_file,
-    onlyif  => 'if(Get-WmiObject -Class Win32_Service -Filter "Name=\'filebeat\'") {exit 0} else {exit 1}',
-    require => Exec["unzip ${filename}"],
-  }
-
-  exec { "rename ${filename}":
-    command => "Remove-Item '${install_folder}' -Recurse -Force -ErrorAction SilentlyContinue;Rename-Item '${filebeat::install_dir}/${filename}' '${install_folder}'", # lint:ignore:140chars
-    creates => $version_file,
-    require => Exec["stop service ${filename}"],
-  }
-
-  exec { "mark ${filename}":
-    command => "New-Item '${version_file}' -ItemType file",
-    creates => $version_file,
-    require => Exec["rename ${filename}"],
-  }
-
-  exec { "install ${filename}":
-    cwd         => $install_folder,
-    command     => './install-service-filebeat.ps1',
-    refreshonly => true,
-    subscribe   => Exec["mark ${filename}"],
+  package {'filebeat':
+    ensure   => $filebeat::package_ensure,
+    provider => 'chocolatey',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,22 +92,22 @@ class filebeat::params {
     }
 
     'Windows' : {
-      $package_ensure   = '5.6.2'
+      $package_ensure   = '6.2.4'
       $config_file_owner = 'Administrator'
       $config_file_group = undef
       $config_dir_owner = 'Administrator'
       $config_dir_group = undef
-      $config_file      = 'C:/Program Files/Filebeat/filebeat.yml'
-      $config_dir       = 'C:/Program Files/Filebeat/conf.d'
-      $registry_file    = 'C:/ProgramData/filebeat/registry'
-      $install_dir      = 'C:/Program Files'
-      $tmp_dir          = 'C:/Windows/Temp'
-      $service_provider = undef
       $url_arch         = $::architecture ? {
         'x86'   => 'x86',
         'x64'   => 'x86_64',
         default => fail("${::architecture} is not supported by filebeat."),
       }
+      $install_dir      = "C:/ProgramData/chocolatey/lib/filebeat/tools/filebeat-${package_ensure}-windows-${url_arch}"
+      $config_file      = "${install_dir}/filebeat.yml"
+      $config_dir       = "${install_dir}/conf.d"
+      $registry_file    = 'C:/ProgramData/filebeat/registry'
+      $tmp_dir          = 'C:/Windows/Temp'
+      $service_provider = undef
     }
 
     default : {

--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -98,7 +98,7 @@ define filebeat::prospector (
 
     'Windows' : {
       $cmd_install_dir = regsubst($filebeat::install_dir, '/', '\\', 'G')
-      $filebeat_path = join([$cmd_install_dir, 'Filebeat', 'filebeat.exe'], '\\')
+      $filebeat_path = join([$cmd_install_dir, 'filebeat.exe'], '\\')
 
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,

--- a/spec/classes/install/windows_spec.rb
+++ b/spec/classes/install/windows_spec.rb
@@ -12,42 +12,9 @@ describe 'filebeat::install::windows' do
       case os_facts[:kernel]
       when 'windows'
         # it { is_expected.to compile }
-        it { is_expected.to contain_file('C:/Program Files').with_ensure('directory') }
         it {
-          is_expected.to contain_archive('C:/Windows/Temp/filebeat-5.6.2-windows-x86_64.zip').with(
-            creates: 'C:/Program Files/Filebeat/filebeat-5.6.2-windows-x86_64',
-          )
-        }
-        it {
-          is_expected.to contain_exec('install filebeat-5.6.2-windows-x86_64').with(
-            command: './install-service-filebeat.ps1',
-          )
-        }
-        it {
-          is_expected.to contain_exec('unzip filebeat-5.6.2-windows-x86_64').with(
-            command: '$sh=New-Object -COM Shell.Application;$sh.namespace((Convert-Path \'C:/Program Files\')).'\
-                     'Copyhere($sh.namespace((Convert-Path \'C:/Windows/Temp/filebeat-5.6.2-windows-x86_64.zip\')).items(), 16)',
-          )
-        }
-        it {
-          is_expected.to contain_exec('mark filebeat-5.6.2-windows-x86_64').with(
-            command: 'New-Item \'C:/Program Files/Filebeat/filebeat-5.6.2-windows-x86_64\' -ItemType file',
-          )
-        }
-        it {
-          is_expected.to contain_exec('rename filebeat-5.6.2-windows-x86_64').with(
-            command: 'Remove-Item \'C:/Program Files/Filebeat\' -Recurse -Force -ErrorAction SilentlyContinue;'\
-                     'Rename-Item \'C:/Program Files/filebeat-5.6.2-windows-x86_64\' \'C:/Program Files/Filebeat\'',
-          )
-        }
-        it {
-          is_expected.to contain_exec('stop service filebeat-5.6.2-windows-x86_64').with(
-            command: 'Set-Service -Name filebeat -Status Stopped',
-          )
-        }
-        it {
-          is_expected.to contain_file('C:/Windows/Temp/filebeat-5.6.2-windows-x86_64.zip').with(
-            ensure: 'absent',
+          is_expected.to contain_package('filebeat').with(
+            ensure: '6.2.4',
           )
         }
 


### PR DESCRIPTION
Adding installation of filebeat using chocolatey.

Bump default install version to 6.2.4

Update tests (they pass on RHEL7 with Puppet 4.10 on Ruby 2.1.9)