### PR TITLE
xpack monitoring configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class filebeat::config {
   $major_version = $filebeat::major_version
 
   if versioncmp($major_version, '6') >= 0 {
-    $filebeat_config = delete_undef_values({
+    $filebeat_config_temp = delete_undef_values({
       'shutdown_timeout'  => $filebeat::shutdown_timeout,
       'name'              => $filebeat::beat_name,
       'tags'              => $filebeat::tags,
@@ -30,6 +30,13 @@ class filebeat::config {
       'processors'        => $filebeat::processors,
       'setup'             => $filebeat::setup,
     })
+    # Add the 'xpack' section if supported (version >= 6.1.0)
+    if versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {
+      $filebeat_config = deep_merge($filebeat_config_temp, {'xpack' => $filebeat::xpack})
+    }
+    else {
+      $filebeat_config = $filebeat_config_temp
+    }
   } else {
     $filebeat_config_temp = delete_undef_values({
       'shutdown_timeout'  => $filebeat::shutdown_timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@
 # @param setup [Hash] setup that will be created. Commonly used to create setup using hiera
 # @param prospectors_merge [Boolean] Whether $prospectors should merge all hiera sources, or use simple automatic parameter lookup
 # proxy_address [String] Proxy server to use for downloading files
+# @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
@@ -88,7 +89,8 @@ class filebeat (
   Hash    $setup                                                      = {},
   Array   $modules                                                    = [],
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address = undef, # lint:ignore:140chars
-  Stdlib::Absolutepath $filebeat_path                                 = $filebeat::params::filebeat_path
+  Stdlib::Absolutepath $filebeat_path                                 = $filebeat::params::filebeat_path,
+  Optional[Hash] $xpack                                               = $filebeat::params::xpack,
 ) inherits filebeat::params {
 
   include ::stdlib

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,7 @@ class filebeat::params {
   $osfamily_fail_message = "${::osfamily} is not supported by filebeat."
   $conf_template         = "${module_name}/pure_hash.yml.erb"
   $disable_config_test   = false
+  $xpack                 = undef
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {


### PR DESCRIPTION
I'd like to send filebeat's internal metrics to an Elasticsearch cluster. In order to do that, the section 'xpack.monitoring' should be added to the configuration file (filebeat.yml).
The $filebeat_config_temp Hash in the class filebeat::config has been appended a key.