### PR TITLE
Add support for OpenBSD.

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -1,8 +1,10 @@
 require 'facter'
 Facter.add('filebeat_version') do
-  confine 'kernel' => %w[FreeBSD Linux Windows]
+  confine 'kernel' => %w[FreeBSD OpenBSD Linux Windows]
   if File.executable?('/usr/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat version')
+  elsif File.executable?('/usr/local/bin/filebeat')
+    filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat --version')
   elsif File.executable?('/usr/share/filebeat/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/share/filebeat/bin/filebeat --version')
   elsif File.executable?('/usr/local/sbin/filebeat')

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,6 +23,10 @@ class filebeat::install {
       }
       Anchor['filebeat::install::begin'] -> Class['filebeat::install::freebsd'] -> Anchor['filebeat::install::end']
     }
+    'OpenBSD': {
+      class{'filebeat::install::openbsd':}
+      Anchor['filebeat::install::begin'] -> Class['filebeat::install::openbsd'] -> Anchor['filebeat::install::end']
+    }
     'Windows': {
       class{'::filebeat::install::windows':
         notify => Class['filebeat::service'],

--- a/manifests/install/openbsd.pp
+++ b/manifests/install/openbsd.pp
@@ -1,0 +1,6 @@
+# to manage filebeat installation on OpenBSD
+class filebeat::install::openbsd {
+  package {'filebeat':
+    ensure => $filebeat::package_ensure,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,13 +38,23 @@ class filebeat::params {
   # }
   #
 
-  # Archlinux has a proper package in the official repos
-  # we shouldn't manage the repo on it
+  # Archlinux and OpenBSD have proper packages in the official repos
+  # we shouldn't manage the repo on them
   case $facts['os']['family'] {
     'Archlinux': {
       $manage_repo = false
       $filebeat_path = '/usr/bin/filebeat'
       $major_version = '6'
+    }
+    'OpenBSD': {
+      $manage_repo = false
+      $filebeat_path = '/usr/local/bin/filebeat'
+      # lint:ignore:only_variable_string
+      $major_version = versioncmp('6.3', "${::kernelversion}") < 0 ? {
+      # lint:endignore
+        true    => '6',
+        default => '5'
+      }
     }
     default: {
       $manage_repo = true
@@ -62,7 +72,6 @@ class filebeat::params {
       $config_dir_owner  = 'root'
       $config_dir_group  = 'root'
       $registry_file     = '/var/lib/filebeat/registry'
-
       # These parameters are ignored if/until tarball installs are supported in Linux
       $tmp_dir         = '/tmp'
       $install_dir     = undef
@@ -86,6 +95,21 @@ class filebeat::params {
       $config_dir_owner  = 'root'
       $config_dir_group  = 'wheel'
       $registry_file     = '/var/lib/filebeat/registry'
+      $tmp_dir           = '/tmp'
+      $service_provider  = undef
+      $install_dir       = undef
+      $url_arch          = undef
+    }
+
+    'OpenBSD': {
+      $package_ensure    = present
+      $config_file       = '/etc/filebeat/filebeat.yml'
+      $config_dir        = '/etc/filebeat/conf.d'
+      $config_file_owner = 'root'
+      $config_file_group = 'wheel'
+      $config_dir_owner  = 'root'
+      $config_dir_group  = 'wheel'
+      $registry_file     = '/var/db/filebeat/.filebeat'
       $tmp_dir           = '/tmp'
       $service_provider  = undef
       $install_dir       = undef

--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -57,7 +57,7 @@ define filebeat::prospector (
   }
 
   case $::kernel {
-    'Linux' : {
+    'Linux', 'OpenBSD' : {
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
         default => $filebeat::major_version ? {
@@ -69,7 +69,7 @@ define filebeat::prospector (
         ensure       => $ensure,
         path         => "${filebeat::config_dir}/${name}.yml",
         owner        => 'root',
-        group        => 'root',
+        group        => '0',
         mode         => $::filebeat::config_file_mode,
         content      => template("${module_name}/${prospector_template}"),
         validate_cmd => $validate_cmd,

--- a/metadata.json
+++ b/metadata.json
@@ -65,6 +65,14 @@
       ]
     },
     {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "6.1",
+        "6.2",
+        "6.3"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",


### PR DESCRIPTION
This adds support for OpenBSD, have it running since quite a while, see the supported version.

Had to add the 
# lint:ignore:only_variable_string
in params.pp, because the test for puppet4 was bailing out on it.

