### PR TITLE
Workaround for #167

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.rb eol=lf
+*.rb eol=lf linguist-language=Puppet
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf

--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -13,6 +13,6 @@ Facter.add('filebeat_version') do
     filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
   end
   setcode do
-    %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1] unless filebeat_version.nil?
+    filebeat_version.nil? ? false : %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1]
   end
 end

--- a/spec/unit/facter/filebeat_version_spec.rb
+++ b/spec/unit/facter/filebeat_version_spec.rb
@@ -16,4 +16,20 @@ describe 'filebeat_version' do
       expect(Facter.fact(:filebeat_version).value).to eq('5.1.1')
     end
   end
+
+  context 'when the filebeat package is not installed' do
+    before :each do
+      File.stubs(:executable?)
+      Facter::Util::Resolution.stubs(:exec)
+      File.expects(:executable?).with('/usr/bin/filebeat').returns false
+      File.expects(:executable?).with('/usr/local/bin/filebeat').returns false
+      File.expects(:executable?).with('/usr/share/filebeat/bin/filebeat').returns false
+      File.expects(:executable?).with('/usr/local/sbin/filebeat').returns false
+      File.stubs(:exist?)
+      File.expects(:exist?).with('c:\Program Files\Filebeat\filebeat.exe').returns false
+    end
+    it 'returns false' do
+      expect(Facter.fact(:filebeat_version).value).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This patch allows the filebeat_version fact to be set to false if the
filebeat package is not installed. Without the package being installed,
there is no other way to guess the filebeat_version.

Also adds a unit test.