### PR TITLE
Custom package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ Installs and configures filebeat.
 - `package_ensure`: [String] The ensure parameter for the filebeat package If set to absent,
   prospectors and processors passed as parameters are ignored and everything managed by
   puppet will be removed. (default: present)
+- `package_name`: [String] Name of the package to install.
+- `oss`: [Boolean] Whether to use the purely open source
+  (i.e., bundled without X-Pack) repository  (default: false)
+- `prerelease`: [Boolean] Whether to use a repo for
+  prerelease versions, like "6.0.0-rc2"  (default: false)
 - `manage_repo`: [Boolean] Whether or not the upstream (elastic) repo should be configured or not (default: true)
 - `major_version`: [Enum] The major version of Filebeat to install. Should be either `5` or `6`. The default value is `5`.
 - `service_ensure`: [String] The ensure parameter on the filebeat service (default: running)

--- a/examples/elasticsearch.pp
+++ b/examples/elasticsearch.pp
@@ -1,0 +1,15 @@
+class { 'filebeat':
+  outputs => {
+    'elasticsearch' => {
+      'hosts'       => [
+        'http://localhost:9200',
+        'http://anotherserver:9200'
+      ],
+      'loadbalance' => true,
+      'index'       => 'packetbeat',
+      'cas'         => [
+        '/etc/pki/root/ca.pem',
+      ],
+    },
+  },
+}

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,0 +1,1 @@
+include '::filebeat'

--- a/examples/oss.pp
+++ b/examples/oss.pp
@@ -1,0 +1,10 @@
+class { '::filebeat':
+  package_ensure => '6.3.1',
+  major_version  => '6',
+  oss            => true,
+  outputs        => {
+    'logstash' => {
+      'hosts' => [ 'localhost:5044', ],
+    },
+  },
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,9 @@
 # }
 #
 # @param package_ensure [String] The ensure parameter for the filebeat package (default: present)
+# @param package_name [String] Name of the package to install.
+# @param oss [Boolean] Whether to use the purely open source (i.e., bundled without X-Pack) repository  (default: false)
+# @param prerelease [Boolean] Whether to use a repo for prerelease versions, like "6.0.0-rc2"  (default: false)
 # @param manage_repo [Boolean] Whether or not the upstream (elastic) repo should be configured or not (default: true)
 # @param major_version [Enum] The major version of Filebeat to be installed.
 # @param service_ensure [String] The ensure parameter on the filebeat service (default: running)
@@ -49,6 +52,9 @@
 # @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
+  String  $package_name                                               = $filebeat::params::package_name,
+  Boolean $oss                                                        = $filebeat::params::oss,
+  Boolean $prerelease                                                 = $filebeat::params::prerelease,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
   Enum['5','6'] $major_version                                        = $filebeat::params::major_version,
   Variant[Boolean, Enum['stopped', 'running']] $service_ensure        = $filebeat::params::service_ensure,
@@ -95,8 +101,13 @@ class filebeat (
 
   include ::stdlib
 
+  $real_package_name = $oss ? {
+    true    => "${package_name}-oss",
+    default => $package_name,
+  }
+
   $real_download_url = $download_url ? {
-    undef   => "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${package_ensure}-windows-${filebeat::params::url_arch}.zip",
+    undef   => "https://artifacts.elastic.co/downloads/beats/filebeat/${$real_package_name}-${package_ensure}-windows-${filebeat::params::url_arch}.zip",
     default => $download_url,
   }
 

--- a/manifests/install/freebsd.pp
+++ b/manifests/install/freebsd.pp
@@ -5,9 +5,12 @@
 # @summary A simple class to install the filebeat package
 #
 class filebeat::install::freebsd {
+  if $filebeat::oss {
+    warning('No OSS version of filebeat available under OpenBSD')
+  }
 
-  # filebeat, heartbeat, metricbeat, packetbeat are all contained in a
-  # single FreeBSD Package (see https://www.freshports.org/sysutils/beats/ )
-  ensure_packages (['beats'], {ensure => $filebeat::package_ensure})
-
+  package {'filebeat':
+    ensure => $filebeat::package_ensure,
+    name   => $filebeat::real_package_name,
+  }
 }

--- a/manifests/install/linux.pp
+++ b/manifests/install/linux.pp
@@ -9,7 +9,21 @@ class filebeat::install::linux {
     fail('filebeat::install::linux shouldn\'t run on Windows')
   }
 
-  package {'filebeat':
+  $absent_package_name = $filebeat::oss ? {
+    false   => "${$filebeat::package_name}-oss",
+    default => $filebeat::package_name,
+  }
+
+  # the official debian packages filebeat and filebeat-oss
+  # do not conflict with each other according to their
+  # meta data; but they have a similar content, resulting
+  # in errors during installation
+  package { 'conflicting filebeat package':
+    ensure => absent,
+    name   => $absent_package_name,
+  }
+  -> package { 'filebeat':
     ensure => $filebeat::package_ensure,
+    name   => $filebeat::real_package_name,
   }
 }

--- a/manifests/install/openbsd.pp
+++ b/manifests/install/openbsd.pp
@@ -1,6 +1,11 @@
 # to manage filebeat installation on OpenBSD
 class filebeat::install::openbsd {
+  if $filebeat::oss {
+    warning('No OSS version of filebeat available under OpenBSD')
+  }
+
   package {'filebeat':
     ensure => $filebeat::package_ensure,
+    name   => $filebeat::real_package_name,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,8 @@ class filebeat::params {
   $conf_template         = "${module_name}/pure_hash.yml.erb"
   $disable_config_test   = false
   $xpack                 = undef
+  $oss                   = false
+  $prerelease            = false
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {
@@ -64,6 +66,7 @@ class filebeat::params {
   }
   case $::kernel {
     'Linux'   : {
+      $package_name      = 'filebeat'
       $package_ensure    = present
       $config_file       = '/etc/filebeat/filebeat.yml'
       $config_dir        = '/etc/filebeat/conf.d'
@@ -87,6 +90,9 @@ class filebeat::params {
     }
 
     'FreeBSD': {
+      # filebeat, heartbeat, metricbeat, packetbeat are all contained in a
+      # single FreeBSD Package (see https://www.freshports.org/sysutils/beats/ )
+      $package_name      = 'beats'
       $package_ensure    = present
       $config_file       = '/usr/local/etc/filebeat.yml'
       $config_dir        = '/usr/local/etc/filebeat.d'
@@ -102,6 +108,7 @@ class filebeat::params {
     }
 
     'OpenBSD': {
+      $package_name      = 'filebeat'
       $package_ensure    = present
       $config_file       = '/etc/filebeat/filebeat.yml'
       $config_dir        = '/etc/filebeat/conf.d'
@@ -117,6 +124,7 @@ class filebeat::params {
     }
 
     'Windows' : {
+      $package_name     = 'filebeat'
       $package_ensure   = '5.6.2'
       $config_file_owner = 'Administrator'
       $config_file_group = undef

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,8 +4,25 @@
 #
 # @summary Manages the yum, apt, and zypp repositories for Filebeat
 class filebeat::repo {
-  $debian_repo_url = "https://artifacts.elastic.co/packages/${filebeat::major_version}.x/apt"
-  $yum_repo_url = "https://artifacts.elastic.co/packages/${filebeat::major_version}.x/yum"
+  if $filebeat::oss {
+    if versioncmp($filebeat::major_version, '6') < 0 {
+      fail('OSS repositories are not available for filebeat <6')
+    }
+
+    $version_prefix = 'oss-'
+  } else {
+    $version_prefix = ''
+  }
+
+  if $filebeat::prerelease {
+    $version_suffix = '.x-prerelease'
+  } else {
+    $version_suffix = '.x'
+  }
+
+  $repo_dir = "${version_prefix}${filebeat::major_version}${version_suffix}"
+  $debian_repo_url = "https://artifacts.elastic.co/packages/${repo_dir}/apt"
+  $yum_repo_url = "https://artifacts.elastic.co/packages/${repo_dir}/yum"
 
   case $::osfamily {
     'Debian': {

--- a/spec/acceptance/002_oss_spec.rb
+++ b/spec/acceptance/002_oss_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper_acceptance'
+
+RSpec.shared_examples 'filebeat-oss' do
+  describe package('filebeat-oss') do
+    it { is_expected.to be_installed }
+  end
+
+  describe package('filebeat') do
+    it { is_expected.not_to be_installed }
+  end
+
+  describe service('filebeat') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe file('/etc/filebeat/filebeat.yml') do
+    it { is_expected.to be_file }
+    it { is_expected.to contain('---') }
+    it { is_expected.not_to contain('xpack') }
+  end
+end
+
+describe 'filebeat class' do
+  let(:pp) do
+    <<-HEREDOC
+    if $::osfamily == 'Debian' {
+      include ::apt
+
+      package { 'apt-transport-https':
+        ensure => present,
+        before => Class['filebeat'],
+      }
+    }
+
+    class { 'filebeat':
+      major_version => '#{major_version}',
+      oss => true,
+      outputs => {
+        'logstash' => {
+          'hosts' => [ 'localhost:5044', ],
+        },
+      },
+    }
+    HEREDOC
+  end
+
+  context 'with $major_version = 5' do
+    let(:major_version) { 5 }
+
+    it 'fails to compile' do
+      expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{OSS repositories are not available for filebeat}i)
+    end
+  end
+
+  context 'with $major_version = 6' do
+    let(:major_version) { 6 }
+
+    it_behaves_like 'an idempotent resource'
+    include_examples 'filebeat-oss'
+  end
+end

--- a/spec/classes/install/linux_spec.rb
+++ b/spec/classes/install/linux_spec.rb
@@ -2,19 +2,65 @@ require 'spec_helper'
 
 describe 'filebeat::install::linux' do
   let :pre_condition do
-    'include ::filebeat'
+    "class { 'filebeat': oss => #{oss}, package_name => #{package_name} }"
   end
 
   on_supported_os(facterversion: '2.4').each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      case os_facts[:kernel]
-      when 'Linux'
-        it { is_expected.to compile }
-        it { is_expected.to contain_package('filebeat').with_ensure('present') }
-      else
-        it { is_expected.not_to compile }
+      context 'with default package name' do
+        let(:oss) { false }
+        let(:package_name) { :undef }
+
+        case os_facts[:kernel]
+        when 'Linux'
+          it { is_expected.to compile }
+          it {
+            is_expected.to contain_package('filebeat').with(
+              'ensure' => 'present',
+              'name'   => 'filebeat',
+            )
+          }
+        else
+          it { is_expected.not_to compile }
+        end
+      end
+
+      context 'with OSS package' do
+        let(:oss) { true }
+        let(:package_name) { :undef }
+
+        case os_facts[:kernel]
+        when 'Linux'
+          it { is_expected.to compile }
+          it {
+            is_expected.to contain_package('filebeat').with(
+              'ensure' => 'present',
+              'name'   => 'filebeat-oss',
+            )
+          }
+        else
+          it { is_expected.not_to compile }
+        end
+      end
+
+      context 'with custom package name' do
+        let(:oss) { false }
+        let(:package_name) { '"filebeat-custom"' }
+
+        case os_facts[:kernel]
+        when 'Linux'
+          it { is_expected.to compile }
+          it {
+            is_expected.to contain_package('filebeat').with(
+              'ensure' => 'present',
+              'name'   => 'filebeat-custom',
+            )
+          }
+        else
+          it { is_expected.not_to compile }
+        end
       end
     end
   end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -4,33 +4,93 @@ describe 'filebeat::repo' do
   on_supported_os(facterversion: '2.4').each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:pre_condition) { "class { 'filebeat': major_version => '#{major_version}' }" }
+      let(:pre_condition) { "class { 'filebeat': major_version => '#{major_version}', oss => #{oss}, prerelease => #{prerelease} }" }
 
       [5, 6].each do |version|
         context "with $major_version == #{version}" do
           let(:major_version) { version }
 
-          case os_facts[:kernel]
-          when 'Linux'
-            it { is_expected.to compile } unless os_facts[:os]['family'] == 'Archlinux'
-            case os_facts[:osfamily]
-            when 'Debian'
-              it {
-                is_expected.to contain_apt__source('beats').with(
-                  ensure: 'present',
-                  location: "https://artifacts.elastic.co/packages/#{major_version}.x/apt",
-                )
-              }
-            when 'RedHat'
-              it {
-                is_expected.to contain_yumrepo('beats').with(
-                  ensure: 'present',
-                  baseurl: "https://artifacts.elastic.co/packages/#{major_version}.x/yum",
-                )
-              }
+          context 'with default flavour settings' do
+            let(:oss) { false }
+            let(:prerelease) { false }
+
+            case os_facts[:kernel]
+            when 'Linux'
+              it { is_expected.to compile } unless os_facts[:os]['family'] == 'Archlinux'
+              case os_facts[:osfamily]
+              when 'Debian'
+                it {
+                  is_expected.to contain_apt__source('beats').with(
+                    ensure: 'present',
+                    location: "https://artifacts.elastic.co/packages/#{major_version}.x/apt",
+                  )
+                }
+              when 'RedHat'
+                it {
+                  is_expected.to contain_yumrepo('beats').with(
+                    ensure: 'present',
+                    baseurl: "https://artifacts.elastic.co/packages/#{major_version}.x/yum",
+                  )
+                }
+              end
+            else
+              it { is_expected.not_to compile }
             end
-          else
-            it { is_expected.not_to compile }
+          end
+
+          context 'with OSS repository' do
+            let(:oss) { true }
+            let(:prerelease) { false }
+
+            if version >= 6 && os_facts[:kernel] == 'Linux'
+              it { is_expected.to compile } unless os_facts[:os]['family'] == 'Archlinux'
+              case os_facts[:osfamily]
+              when 'Debian'
+                it {
+                  is_expected.to contain_apt__source('beats').with(
+                    ensure: 'present',
+                    location: "https://artifacts.elastic.co/packages/oss-#{major_version}.x/apt",
+                  )
+                }
+              when 'RedHat'
+                it {
+                  is_expected.to contain_yumrepo('beats').with(
+                    ensure: 'present',
+                    baseurl: "https://artifacts.elastic.co/packages/oss-#{major_version}.x/yum",
+                  )
+                }
+              end
+            else
+              it { is_expected.not_to compile }
+            end
+          end
+
+          context 'with prerelease repository' do
+            let(:oss) { false }
+            let(:prerelease) { true }
+
+            case os_facts[:kernel]
+            when 'Linux'
+              it { is_expected.to compile } unless os_facts[:os]['family'] == 'Archlinux'
+              case os_facts[:osfamily]
+              when 'Debian'
+                it {
+                  is_expected.to contain_apt__source('beats').with(
+                    ensure: 'present',
+                    location: "https://artifacts.elastic.co/packages/#{major_version}.x-prerelease/apt",
+                  )
+                }
+              when 'RedHat'
+                it {
+                  is_expected.to contain_yumrepo('beats').with(
+                    ensure: 'present',
+                    baseurl: "https://artifacts.elastic.co/packages/#{major_version}.x-prerelease/yum",
+                  )
+                }
+              end
+            else
+              it { is_expected.not_to compile }
+            end
           end
         end
       end


### PR DESCRIPTION
when using the OSS repository, the package is named *filebeat-oss*; at least under linux and windows environments.

this PR adds support for the OSS apt and yum repositories, as well as a custom package name.
this behaviour is similar to the elastic puppet modules.

when setting the *oss* parameter to **true** under \*BSD environments, the catalog will most likely fail, as there are no *-oss* variants of the beats packages. i chose not to emit a warning should this constellation arise as i assume the user knows what they are doing.

the config refactoring is not necessarily required, as the OSS variant of filebeat currently ignores the xpack config, should it be present. since other elastic products in their OSS variant complain when they are provided with xpack config, i chose to follow that principle and remove any undefined parameters from the configuration before writing it to the file.

fixes #177