### PR TITLE
README file updates regarding Filebeat 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ class { 'filebeat':
        'http://anotherserver:9200'
      ],
      'loadbalance' => true,
-     'index'       => 'packetbeat',
      'cas'         => [
         '/etc/pki/root/ca.pem',
      ],

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Installs and configures filebeat.
   prospectors and processors passed as parameters are ignored and everything managed by
   puppet will be removed. (default: present)
 - `manage_repo`: [Boolean] Whether or not the upstream (elastic) repo should be configured or not (default: true)
-- `major_version`: [Enum] The major version of Filebeat to install. Should be either `5` or `6`. The default value is `5`.
+- `major_version`: [Enum] The major version of Filebeat to install. Should be either `'5'` or `'6'`. The default value is `'6'`, except
+   for OpenBSD 6.3 and earlier, which has a default value of `'5'`.
 - `service_ensure`: [String] The ensure parameter on the filebeat service (default: running)
 - `service_enable`: [String] The enable parameter on the filebeat service (default: true)
 - `param repo_priority`: [Integer] Repository priority.  yum and apt supported (default: undef)


### PR DESCRIPTION
Thank you for publishing this very useful module.

This PR updates the information about the default value of major_version in the README file. It also changes the configuration example for the ElasticSearch output so it works with Filebeat 6.