### PR TITLE
Add manage_apt flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@
 #
 # @param package_ensure [String] The ensure parameter for the filebeat package (default: present)
 # @param manage_repo [Boolean] Whether or not the upstream (elastic) repo should be configured or not (default: true)
+# @param manage_apt [Boolean] Whether or not the apt class should be explicitly called or not (default: true)
 # @param major_version [Enum] The major version of Filebeat to be installed.
 # @param service_ensure [String] The ensure parameter on the filebeat service (default: running)
 # @param service_enable [String] The enable parameter on the filebeat service (default: true)
@@ -50,6 +51,7 @@
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
+  Boolean $manage_apt                                                 = $filebeat::params::manage_apt,
   Enum['5','6'] $major_version                                        = $filebeat::params::major_version,
   Variant[Boolean, Enum['stopped', 'running']] $service_ensure        = $filebeat::params::service_ensure,
   Boolean $service_enable                                             = $filebeat::params::service_enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,11 +43,13 @@ class filebeat::params {
   case $facts['os']['family'] {
     'Archlinux': {
       $manage_repo = false
+      $manage_apt  = false
       $filebeat_path = '/usr/bin/filebeat'
       $major_version = '6'
     }
     'OpenBSD': {
       $manage_repo = false
+      $manage_apt  = false
       $filebeat_path = '/usr/local/bin/filebeat'
       # lint:ignore:only_variable_string
       $major_version = versioncmp('6.3', "${::kernelversion}") < 0 ? {
@@ -58,6 +60,7 @@ class filebeat::params {
     }
     default: {
       $manage_repo = true
+      $manage_apt  = true
       $filebeat_path = '/usr/share/filebeat/bin/filebeat'
       $major_version = '6'
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,7 +9,9 @@ class filebeat::repo {
 
   case $::osfamily {
     'Debian': {
-      include ::apt
+      if $manage_apt == true {
+        include ::apt
+      }
 
       Class['apt::update'] -> Package['filebeat']
 


### PR DESCRIPTION
The repo class currently calls "include ::apt" - unfortunately this module has a bunch of tuneables I need to set elsewhere.

The cleanest fix I could manage without significant surgery was just to make that include a tuneable itself.