### PR TITLE
Allow puppetlabs-apt 6.x and newer

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <5.0.0"
+      "version_requirement": ">=2.0.0 <7.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
Update allowed version requirements after the 6.0.0 release of the puppetlabs apt module on 2018-08-24 (https://github.com/puppetlabs/puppetlabs-apt/blob/master/CHANGELOG.md)