### PR TITLE
Fix undef xpack

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,8 +30,8 @@ class filebeat::config {
       'processors'        => $filebeat::processors,
       'setup'             => $filebeat::setup,
     })
-    # Add the 'xpack' section if supported (version >= 6.1.0)
-    if versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {
+    # Add the 'xpack' section if supported (version >= 6.1.0) and not undef
+    if $filebeat::xpack and versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {
       $filebeat_config = deep_merge($filebeat_config_temp, {'xpack' => $filebeat::xpack})
     }
     else {


### PR DESCRIPTION
xpack parameter is being added after `delete_undef_values` has cleaned
the configuration hash.  With this change, it won't be merged with
`filebeat_config_temp` if it's `undef`.