### PR TITLE
Produce valid processors configuration

### DIFF
--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -192,10 +192,5 @@
   <%- if @processors.length > 0 -%>
   # Managing processors releated only for specified prospector
   processors:
-    <%- @processors.each do |proc| -%>
-  - <%= proc.keys[0] %>:
-      <%- proc[proc.keys[0]].each do |k, v| -%>
-      <%= k %>: <%= v %>
-      <%- end -%>
-    <%- end -%>
+    <%- %><%= @processors.to_yaml.lines[1..-1].join.gsub(/^/, '  ') -%>
   <%- end -%>


### PR DESCRIPTION
Great module! I ran into one problem when trying to define processors. It was producing stringified versions of the configuration hashes and arrays instead of valid yaml.

Here's my correction. I'm taking the entire hash and generating the yaml from that.

Thanks!