### PR TITLE
Fix undefined method error in Puppet 4.10

### DIFF
--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -194,5 +194,5 @@
   <%- if @processors.length > 0 -%>
   # Managing processors releated only for specified prospector
   processors:
-    <%- %><%= @processors.to_yaml.lines[1..-1].join.gsub(/^/, '  ') -%>
+    <%- %><%= @processors.to_yaml.lines.drop(1).join.gsub(/^/, '  ') -%>
   <%- end -%>


### PR DESCRIPTION
The previous implementation of #193 broke support with Puppet Server 4.10.

Basically, we were getting the following error:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Failed to parse templatefilebeat/prospector.yml.erb:
Filepath: /etc/puppetlabs/code/environments/<MY NICE ENVIRONMENT NAME>/modules/filebeat/templates/prospector.yml.erb
Line: 195
Detail: undefined method `[]' for #<Enumerator:0x7968727a>
at /etc/puppetlabs/code/environments/<MY NICE ENVIRONMENT NAME>/modules/filebeat/manifests/prospector.pp:79:25 at /etc/puppetlabs/code/environments/<MY NICE ENVIRONMENT NAME>/modules/kubernetes_realized/manifests/init.pp:128 on node <NODENAME>
```

This was caused by the fact that on earlier Puppet/Ruby versions the method `lines` was returning an Enumerator object, and it did not support the Array [n...-n] method.

Luckily, `zenspider` on Ruby@Freenode were kind enough to debug with me.

They suggested using the `drop` method, which is supported on both, Array and Enumerator classes.

https://ruby-doc.org/core-2.0.0/Enumerable.html#method-i-drop
https://ruby-doc.org/core-2.0.0/Array.html#method-i-drop