### PR TITLE
Fix filebeat::prospector::fields_under_root

### DIFF
--- a/manifests/prospector.pp
+++ b/manifests/prospector.pp
@@ -18,7 +18,7 @@ define filebeat::prospector (
   String $encoding                   = 'plain',
   String $input_type                 = 'log',
   Hash $fields                       = {},
-  Boolean $fields_under_root         = false,
+  Boolean $fields_under_root         = $filebeat::fields_under_root,
   Optional[String] $ignore_older     = undef,
   Optional[String] $close_older      = undef,
   String $doc_type                   = 'log',


### PR DESCRIPTION
`filebeat::prospector::fields_under_root` had hardcoded value instead of following global variable set for whole module `filebeat`, thus setting global `filebeat::fields_under_root: true` had no effect.