### PR TITLE
Support filebeat.registry_flush in filebeat.yml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class filebeat::config {
       'fields_under_root' => $filebeat::fields_under_root,
       'filebeat'          => {
         'registry_file'      => $filebeat::registry_file,
+        'registry_flush'     => $filebeat::registry_flush,
         'config.prospectors' => {
           'enabled' => true,
           'path'    => "${filebeat::config_dir}/*.yml",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@
 # @param idle_timeout [String] How often the spooler should be flushed even if spool size isn't reached (default: 5s)
 # @param publish_async [Boolean] If set to true filebeat will publish while preparing the next batch of lines to send (defualt: false)
 # @param registry_file [String] The registry file used to store positions, absolute or relative to working directory (default .filebeat)
+# @param registry_flush [String] The timeout value that controls when registry entries are written to disk (default: 0s)
 # @param config_dir [String] The directory where prospectors should be defined (default: /etc/filebeat/conf.d)
 # @param config_dir_mode [String] The unix permissions mode set on the configuration directory (default: 0755)
 # @param config_file_mode [String] The unix permissions mode set on configuration files (default: 0644)
@@ -61,6 +62,7 @@ class filebeat (
   String  $idle_timeout                                               = $filebeat::params::idle_timeout,
   Boolean $publish_async                                              = $filebeat::params::publish_async,
   String  $registry_file                                              = $filebeat::params::registry_file,
+  String  $registry_flush                                             = $filebeat::params::registry_flush,
   String  $config_file                                                = $filebeat::params::config_file,
   Optional[String] $config_file_owner                                 = $filebeat::params::config_file_owner,
   Optional[String] $config_file_group                                 = $filebeat::params::config_file_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,6 +87,7 @@ class filebeat::params {
         }
       }
       $url_arch        = undef
+      $registry_flush  = undef
     }
 
     'FreeBSD': {
@@ -102,6 +103,7 @@ class filebeat::params {
       $service_provider  = undef
       $install_dir       = undef
       $url_arch          = undef
+      $registry_flush    = undef
     }
 
     'OpenBSD': {
@@ -117,6 +119,7 @@ class filebeat::params {
       $service_provider  = undef
       $install_dir       = undef
       $url_arch          = undef
+      $registry_flush    = undef
     }
 
     'Windows' : {
@@ -136,6 +139,7 @@ class filebeat::params {
         'x64'   => 'x86_64',
         default => fail("${::architecture} is not supported by filebeat."),
       }
+      $registry_flush    = undef
     }
 
     default : {

--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -6,6 +6,9 @@ filebeat.publish_async: <%= @filebeat_config['filebeat']['publish_async'] %>
 filebeat.idle_timeout: <%= @filebeat_config['filebeat']['idle_timeout'] %>
 <% end -%>
 filebeat.registry_file: <%= @filebeat_config['filebeat']['registry_file'] %>
+<%- if @filebeat_config['registry_flush'] != nil -%>
+filebeat.registry_flush: <%= @filebeat_config['registry_flush'] %>
+<%- end -%>
 filebeat.config_dir: <%= @filebeat_config['filebeat']['config_dir'] %>
 filebeat.shutdown_timeout: <%= @filebeat_config['filebeat']['shutdown_timeout'] %>
 


### PR DESCRIPTION
This can be used to prevent the registry file being updated in an
infinite loop as described here:

https://discuss.elastic.co/t/registry-load-gets-caught-in-infinite-loop/145717/3