### PR TITLE
fix breakage when filebeat is not yet installed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,7 +73,7 @@ class filebeat::config {
     }
   }
 
-  if 'filebeat_version' in $facts {
+  if 'filebeat_version' in $facts and $facts['filebeat_version'] != false {
     $skip_validation = versioncmp($facts['filebeat_version'], $filebeat::major_version) ? {
       -1      => true,
       default => false,

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -53,7 +53,7 @@ define filebeat::input (
     default => 'prospector.yml.erb',
   }
 
-  if 'filebeat_version' in $facts {
+  if 'filebeat_version' in $facts and $facts['filebeat_version'] != false {
     $skip_validation = versioncmp($facts['filebeat_version'], $filebeat::major_version) ? {
       -1      => true,
       default => false,


### PR DESCRIPTION
When filebeat is not yet installed, the filebeat_version fact returns
false, which doesn't work well with versioncmp, and you end up 
with the puppet run with following error message:

Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Boolean (file: /etc/puppetlabs/code/environments/production/modules/filebeat/manifests/config.pp, line: 77, column: 24) (file: /etc/puppetlabs/code/environments/production/modules/profile/manifests/init.pp, line: 140) on node test.example.com