### PR TITLE
Adding support for version check of Windows filebeat version 5 though 7

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -11,7 +11,7 @@ Facter.add('filebeat_version') do
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/sbin/filebeat --version')
   elsif File.exist?('c:\Program Files\Filebeat\filebeat.exe')
     filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" version')
-    if filebeat_version.empty? 
+    if filebeat_version.empty?
       filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
     end
   end

--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -10,7 +10,10 @@ Facter.add('filebeat_version') do
   elsif File.executable?('/usr/local/sbin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/sbin/filebeat --version')
   elsif File.exist?('c:\Program Files\Filebeat\filebeat.exe')
-    filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
+    filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" version')
+    if filebeat_version.empty? 
+      filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
+    end
   end
   setcode do
     filebeat_version.nil? ? false : %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1]


### PR DESCRIPTION
The version option for filebeat on Windows version 5 included the option for one or 2 hyphens.  This was deprecated in 6 in favour of no hyphens and removed in 7.