### PR TITLE
Adding support for config file validation for version 7 on Windows

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -185,7 +185,10 @@ class filebeat::config {
 
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
-        default => "\"${filebeat_path}\" -N -configtest -c \"%\"",
+        default => $major_version ? {
+          '7'     => "\"${filebeat_path}\" test config -c \"%\"",
+          default => "\"${filebeat_path}\" -N -configtest -c \"%\"",
+        }
       }
 
       file {'filebeat.yml':


### PR DESCRIPTION
Config file testing commands have changed for Windows.