### PR TITLE
overide default logging with filebeat version 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,11 +407,13 @@ class {'filebeat':
     },
   systemd_beat_log_opts_override => "",
 }
+```
 
-this will only work on systems with puppet version 6.1+. on systems with puppet version < 6.1 you will need to `systemctl daemon-reload`. This can be achived by using the [camptocamp-systemd](https://forge.puppet.com/camptocamp/systemd)
+this will only work on systems with puppet version 6.1+. On systems with puppet version < 6.1 you will need to `systemctl daemon-reload`. This can be achived by using the [camptocamp-systemd](https://forge.puppet.com/camptocamp/systemd)
 
 ```puppet
 include systemd::systemctl::daemon_reload
+
 class {'filebeat':
   logging => {
 ...

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,8 @@ class filebeat (
   Integer $queue_size                                                 = 4096,
   String $registry_file                                               = 'filebeat.yml',
 
-  String $systemd_log_opt_template                                    = $filebeat::params::systemd_log_opt_template,
+  Optional[String] $systemd_beat_log_opts_override                    = undef,
+  String $systemd_beat_log_opts_template                              = $filebeat::params::systemd_beat_log_opts_template,
   String $systemd_drop_in_dir                                         = $filebeat::params::systemd_drop_in_dir,
 
 ) inherits filebeat::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,7 +99,7 @@ class filebeat (
 
   Optional[String] $systemd_beat_log_opts_override                    = undef,
   String $systemd_beat_log_opts_template                              = $filebeat::params::systemd_beat_log_opts_template,
-  String $systemd_drop_in_dir                                         = $filebeat::params::systemd_drop_in_dir,
+  String $systemd_override_dir                                        = $filebeat::params::systemd_override_dir,
 
 ) inherits filebeat::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,9 @@ class filebeat (
   Integer $queue_size                                                 = 4096,
   String $registry_file                                               = 'filebeat.yml',
 
+  String $systemd_log_opt_template                                    = $filebeat::params::systemd_log_opt_template,
+  String $systemd_drop_in_dir                                         = $filebeat::params::systemd_drop_in_dir,
+
 ) inherits filebeat::params {
 
   include ::stdlib

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class filebeat::params {
   $conf_template            = "${module_name}/pure_hash.yml.erb"
   $disable_config_test      = false
   $xpack                    = undef
-  $systemd_drop_in_dir      = '/etc/systemd/system/filebeat.service.d'
+  $systemd_override_dir     = '/etc/systemd/system/filebeat.service.d'
   $systemd_beat_log_opts_template = "${module_name}/systemd/logging.conf.erb"
 
   # These are irrelevant as long as the template is set based on the major_version parameter

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,32 +4,34 @@
 #
 # @summary Set a bunch of default parameters
 class filebeat::params {
-  $service_ensure        = running
-  $service_enable        = true
-  $spool_size            = 2048
-  $idle_timeout          = '5s'
-  $publish_async         = false
-  $shutdown_timeout      = '0'
-  $beat_name             = $::fqdn
-  $tags                  = []
-  $max_procs             = undef
-  $config_file_mode      = '0644'
-  $config_dir_mode       = '0755'
-  $purge_conf_dir        = true
-  $enable_conf_modules   = false
-  $fields                = {}
-  $fields_under_root     = false
-  $http                  = {}
-  $outputs               = {}
-  $shipper               = {}
-  $logging               = {}
-  $run_options           = {}
-  $modules               = []
-  $kernel_fail_message   = "${::kernel} is not supported by filebeat."
-  $osfamily_fail_message = "${::osfamily} is not supported by filebeat."
-  $conf_template         = "${module_name}/pure_hash.yml.erb"
-  $disable_config_test   = false
-  $xpack                 = undef
+  $service_ensure           = running
+  $service_enable           = true
+  $spool_size               = 2048
+  $idle_timeout             = '5s'
+  $publish_async            = false
+  $shutdown_timeout         = '0'
+  $beat_name                = $::fqdn
+  $tags                     = []
+  $max_procs                = undef
+  $config_file_mode         = '0644'
+  $config_dir_mode          = '0755'
+  $purge_conf_dir           = true
+  $enable_conf_modules      = false
+  $fields                   = {}
+  $fields_under_root        = false
+  $http                     = {}
+  $outputs                  = {}
+  $shipper                  = {}
+  $logging                  = {}
+  $run_options              = {}
+  $modules                  = []
+  $kernel_fail_message      = "${::kernel} is not supported by filebeat."
+  $osfamily_fail_message    = "${::osfamily} is not supported by filebeat."
+  $conf_template            = "${module_name}/pure_hash.yml.erb"
+  $disable_config_test      = false
+  $xpack                    = undef
+  $systemd_drop_in_dir      = '/etc/systemd/system/filebeat.service.d'
+  $systemd_log_opt_template = "${module_name}/systemd/logging.conf.erb"
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class filebeat::params {
   $disable_config_test      = false
   $xpack                    = undef
   $systemd_drop_in_dir      = '/etc/systemd/system/filebeat.service.d'
-  $systemd_log_opt_template = "${module_name}/systemd/logging.conf.erb"
+  $systemd_beat_log_opts_template = "${module_name}/systemd/logging.conf.erb"
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,11 +10,19 @@ class filebeat::service {
     provider => $filebeat::service_provider,
   }
 
-  $major_version = $filebeat::major_version
+  $major_version                  = $filebeat::major_version
+  $systemd_beat_log_opts_override = $filebeat::systemd_beat_log_opts_override
 
-  if versioncmp($major_version, '7') >= 0 {
+  #make sure puppet client version 6.1+ with filebeat version 7+, running on systemd
+  if ( versioncmp( $major_version, '7'   ) >= 0 and
+      versioncmp( $::clientversion, '6.1' ) >= 0 and
+      $::service_provider == 'systemd' ) {
 
-    $logging = $filebeat::logging
+    unless $systemd_beat_log_opts_override == undef {
+      $ensure_overide = 'present'
+    } else {
+      $ensure_overide = 'absent'
+    }
 
     ensure_resource('file',
       $filebeat::systemd_drop_in_dir,
@@ -26,8 +34,8 @@ class filebeat::service {
     ensure_resource('file',
       "${filebeat::systemd_drop_in_dir}/logging.conf",
       {
-        ensure  => 'present',
-        content => template($filebeat::systemd_log_opt_template),
+        ensure  => $ensure_overide,
+        content => template($filebeat::systemd_beat_log_opts_template),
         require => File[$filebeat::systemd_drop_in_dir],
         notify  => Service['filebeat'],
       }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,4 +9,29 @@ class filebeat::service {
     enable   => $filebeat::service_enable,
     provider => $filebeat::service_provider,
   }
+
+  $major_version = $filebeat::major_version
+
+  if versioncmp($major_version, '7') >= 0 {
+
+    $logging = $filebeat::logging
+
+    ensure_resource('file',
+      $filebeat::systemd_drop_in_dir,
+      {
+        ensure => 'directory',
+      }
+    )
+
+    ensure_resource('file',
+      "${filebeat::systemd_drop_in_dir}/logging.conf",
+      {
+        ensure  => 'present',
+        content => template($filebeat::systemd_log_opt_template),
+        require => File[$filebeat::systemd_drop_in_dir],
+        notify  => Service['filebeat'],
+      }
+    )
+
+  }
 }

--- a/templates/systemd/logging.conf.erb
+++ b/templates/systemd/logging.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-Environment="BEAT_LOG_OPTS=<%= '-e' if @logging.empty? %>"
+Environment="BEAT_LOG_OPTS=<%= @systemd_beat_log_opts_override %>"

--- a/templates/systemd/logging.conf.erb
+++ b/templates/systemd/logging.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+Environment="BEAT_LOG_OPTS=<%= '-e' if @logging.empty? %>"


### PR DESCRIPTION
This PR overrides default logging with filebeat version 7 running on systems running systemd

Since filebeat version 7,  systemd service file hard codes the flag `-e`. this option sets the logging to syslog and will ignore any logging set by this puppet module.

This change creates a systemd drop-in file for filebeat that drops the `-e` flag if a $logging hash is set when using the class




