### PR TITLE
Update facter script to work with hideously old filebeat

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -3,6 +3,9 @@ Facter.add('filebeat_version') do
   confine 'kernel' => ['FreeBSD', 'OpenBSD', 'Linux', 'Windows']
   if File.executable?('/usr/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat version')
+    if filebeat_version.empty?
+      filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat --version')
+    end
   elsif File.executable?('/usr/local/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat --version')
   elsif File.executable?('/usr/share/filebeat/bin/filebeat')


### PR DESCRIPTION
We unfortunately have some filebeat 1.x hanging around and if this module is applied it complains about `undefined method `[]' for nil:NilClass` because the really old filebeat used `filebeat --version` instead of the new fancy `filebeat version` . I had modified our local version of the module to use that, but now that we're looking at 7.x that fix doesn't work as `--version` is now an error. Saw the empty version handling for the Windows clients and thought the same could be applied to make the super old ugly busted filebeat 1.x stuff happy as well.

Totally understand if supporting viciously outdated code is not worthy of a merge.