### PR TITLE
removed full path to yum from repo.pp

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,7 +44,7 @@ class filebeat::repo {
       }
 
       exec { 'flush-yum-cache':
-        command     => '/bin/yum clean all',
+        command     => 'yum clean all',
         refreshonly => true,
         path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
       }


### PR DESCRIPTION
Centos 6 uses /usr/bin/yum and full path to the command doesn't work.