### PR TITLE
Fix filebeat_version fact in some circumstances

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -7,7 +7,10 @@ Facter.add('filebeat_version') do
       filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat --version')
     end
   elsif File.executable?('/usr/local/bin/filebeat')
-    filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat --version')
+    filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat version')
+    if filebeat_version.empty?
+      filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat --version')
+    end
   elsif File.executable?('/usr/share/filebeat/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/share/filebeat/bin/filebeat --version')
   elsif File.executable?('/usr/local/sbin/filebeat')


### PR DESCRIPTION
Not every filebeat that is installed in /usr/local/bin may
understand the --version parameter as used in the filebeat_version.rb
At least on OpenBSD, it should use filebeat version to properly
detect the version.
Use the same approch as it is done when filebeat is found in
/usr/bin, test both --version and version.