### PR TITLE
Add support for setting 'migration.6_to_7.enabled'

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,12 +45,18 @@ class filebeat::config {
       'processors'        => $filebeat::processors,
       'setup'             => $setup,
     })
+    # Add the migration.6_to_7.enabled section, if requested:
+    if $filebeat::migrate_67 {
+      $filebeat_config_temp_migrate = deep_merge($filebeat_config_temp, { 'migration.6_to_7.enabled' => true })
+    } else {
+      $filebeat_config_temp_migrate = $filebeat_config_temp
+    }
     # Add the 'xpack' section if supported (version >= 6.1.0) and not undef
     if $filebeat::xpack and versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {
-      $filebeat_config = deep_merge($filebeat_config_temp, {'xpack' => $filebeat::xpack})
+      $filebeat_config = deep_merge($filebeat_config_temp_migrate, {'xpack' => $filebeat::xpack})
     }
     else {
-      $filebeat_config = $filebeat_config_temp
+      $filebeat_config = $filebeat_config_temp_migrate
     }
   } else {
     $filebeat_config_temp = delete_undef_values({

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@
 # @param inputs_merge [Boolean] Whether $inputs should merge all hiera sources, or use simple automatic parameter lookup
 # proxy_address [String] Proxy server to use for downloading files
 # @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
+# @param migrate_67 [Boolean] Decides whether to add the migration.6_to_7.enabled setting (default: false)
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
@@ -86,6 +87,7 @@ class filebeat (
   Hash $fields                                                        = $filebeat::params::fields,
   Boolean $fields_under_root                                          = $filebeat::params::fields_under_root,
   Boolean $disable_config_test                                        = $filebeat::params::disable_config_test,
+  Boolean $migrate_67                                                 = $filebeat::params::migrate_67,
   Array   $processors                                                 = [],
   Hash    $inputs                                                     = {},
   Hash    $setup                                                      = {},

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@ class filebeat::params {
   $conf_template            = "${module_name}/pure_hash.yml.erb"
   $disable_config_test      = false
   $xpack                    = undef
+  $migrate_67               = false
   $systemd_override_dir     = '/etc/systemd/system/filebeat.service.d'
   $systemd_beat_log_opts_template = "${module_name}/systemd/logging.conf.erb"
 


### PR DESCRIPTION
The title says it all really. I needed to be able to set the 'migration.6_to_7.enabled' config parameter, but couldn't find a way to do it with the existing module. I've added it as a simple Boolean option, defaulted to false, and it works for me. 