### PR TITLE
Allow fields and tags to be defined for any input type

### DIFF
--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -3,6 +3,19 @@
 <%- else -%>
 ---
 - type: <%= @input_type %>
+  <%- if @fields.length > 0 -%>
+  fields:
+    <%- @fields.each_pair do |k, v| -%>
+    <%= k %>: <%= v %>
+    <%- end -%>
+  <%- end -%>
+  fields_under_root: <%= @fields_under_root %>
+  <%- if @tags.length > 0 -%>
+  tags:
+    <%- @tags.each do |tag| -%>
+    - <%= tag %>
+    <%- end -%>
+  <%- end -%>
   <%- if @input_type == 'docker' -%>
   containers:
     ids:
@@ -40,19 +53,6 @@
   exclude_files:
     <%- @exclude_files.each do |exclude_file| -%>
     - <%= exclude_file %>
-    <%- end -%>
-  <%- end -%>
-  <%- if @fields.length > 0 -%>
-  fields:
-    <%- @fields.each_pair do |k, v| -%>
-    <%= k %>: <%= v %>
-    <%- end -%>
-  <%- end -%>
-  fields_under_root: <%= @fields_under_root %>
-  <%- if @tags.length > 0 -%>
-  tags:
-    <%- @tags.each do |tag| -%>
-    - <%= tag %>
     <%- end -%>
   <%- end -%>
   <%- if @ignore_older -%>


### PR DESCRIPTION
This PR simply moves the fields and tags logic outside of the input type if/else so that no matter what input type you select, you still have the option of defining fields or tags.