### PR TITLE
Disable the filebeat service if package is absent.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,11 +121,13 @@ class filebeat (
     $real_service_ensure = 'stopped'
     $file_ensure = 'absent'
     $directory_ensure = 'absent'
+    $real_service_enable = false
   } else {
     $alternate_ensure = 'present'
     $file_ensure = 'file'
     $directory_ensure = 'directory'
     $real_service_ensure = $service_ensure
+    $real_service_enable = $service_enable
   }
 
   # If we're removing filebeat, do things in a different order to make sure

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@
 class filebeat::service {
   service { 'filebeat':
     ensure   => $filebeat::real_service_ensure,
-    enable   => $filebeat::service_enable,
+    enable   => $filebeat::real_service_enable,
     provider => $filebeat::service_provider,
   }
 


### PR DESCRIPTION
# Summary
I tried to remove the filebeat agent with Puppet and got an error.

# Hiera
```Yaml
filebeat::package_ensure: 'absent'
```

# Actual result
```
Notice: /Stage[main]/Filebeat::Config/File[filebeat-config-dir]/ensure: removed
Info: Computing checksum on file /etc/filebeat/filebeat.yml
Info: /Stage[main]/Filebeat::Config/File[filebeat.yml]: Filebucketed /etc/filebeat/filebeat.yml to puppet with sum eaefecc59e6056a455f8a0e9cc205cb6
Notice: /Stage[main]/Filebeat::Config/File[filebeat.yml]/ensure: removed
Info: /Stage[main]/Filebeat::Config/File[filebeat.yml]: Scheduling refresh of Service[filebeat]
Notice: /Stage[main]/Filebeat::Install::Linux/Package[filebeat]/ensure: removed
Info: Class[Filebeat::Install::Linux]: Scheduling refresh of Class[Filebeat::Service]
Info: Class[Filebeat::Service]: Scheduling refresh of Service[filebeat]
Error: Could not enable filebeat: Execution of '/sbin/chkconfig --add filebeat' returned 1: error reading information on service filebeat: No such file or directory
Error: /Stage[main]/Filebeat::Service/Service[filebeat]/ensure: change from 'running' to 'stopped' failed: Could not enable filebeat: Execution of '/sbin/chkconfig --add filebeat' returned 1: error reading information on service filebeat: No such file or directory
Notice: /Stage[main]/Filebeat::Service/Service[filebeat]: Triggered 'refresh' from 2 events
Info: Class[Filebeat::Service]: Unscheduling all events on Class[Filebeat::Service]
Notice: /Stage[main]/Filebeat/Anchor[filebeat::end]: Dependency Service[filebeat] has failures: true
Warning: /Stage[main]/Filebeat/Anchor[filebeat::end]: Skipping because of failed dependencies
Info: Stage[main]: Unscheduling all events on Stage[main]
```

# Expected result
The following should be removed
* Repository
* Package
* Config
* Service