### PR TITLE
Add support for Windows Server 2016 and 2019 Core editions

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -14,7 +14,7 @@ class filebeat::install::windows {
   $foldername = 'Filebeat'
   $zip_file = join([$filebeat::tmp_dir, "${filename}.zip"], '/')
   $install_folder = join([$filebeat::install_dir, $foldername], '/')
-  $version_file = join([$install_folder, $filename], '/')
+  $version_file = join([$filebeat::install_dir, $filename], '/')
 
   Exec {
     provider => powershell,

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -38,7 +38,7 @@ class filebeat::install::windows {
   }
 
   exec { "unzip ${filename}":
-    command => "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path '${filebeat::install_dir}')).Copyhere(\$sh.namespace((Convert-Path '${zip_file}')).items(), 16)", # lint:ignore:140chars
+    command => "Expand-Archive ${zip_file} ${filebeat::install_dir}",
     creates => $version_file,
     require => [
       File[$filebeat::install_dir],

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -14,7 +14,7 @@ class filebeat::install::windows {
   $foldername = 'Filebeat'
   $zip_file = join([$filebeat::tmp_dir, "${filename}.zip"], '/')
   $install_folder = join([$filebeat::install_dir, $foldername], '/')
-  $version_file = join([$filebeat::install_dir, $filename], '/')
+  $version_file = join([$install_folder, $filename], '/')
 
   Exec {
     provider => powershell,

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -38,7 +38,7 @@ class filebeat::install::windows {
   }
 
   exec { "unzip ${filename}":
-    command => "Expand-Archive ${zip_file} ${filebeat::install_dir}",
+    command => "Expand-Archive ${zip_file} \"${filebeat::install_dir}\"",
     creates => $version_file,
     require => [
       File[$filebeat::install_dir],

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -37,8 +37,20 @@ class filebeat::install::windows {
     proxy_server => $filebeat::proxy_address,
   }
 
+  # Core editions of Windows Server do not have a shell as such, so use the Shell.Application COM object doesn't work.
+  # Expand-Archive is a native powershell cmdlet which ships with Powershell 5, which in turn ships with Windows 10 and 
+  # Windows Server 2016 and newer.
+  if ((versioncmp($::operatingsystemrelease, '2016') > 0) or (versioncmp($::operatingsystemrelease, '10') == 0))
+  {
+    $unzip_command = "Expand-Archive ${zip_file} \"${filebeat::install_dir}\""
+  }
+  else
+  {
+    $unzip_command = "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path '${filebeat::install_dir}')).Copyhere(\$sh.namespace((Convert-Path '${zip_file}')).items(), 16)" # lint:ignore:140chars
+  }
+
   exec { "unzip ${filename}":
-    command => "Expand-Archive ${zip_file} \"${filebeat::install_dir}\"",
+    command => $unzip_command,
     creates => $version_file,
     require => [
       File[$filebeat::install_dir],

--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,9 @@
       "operatingsystem": "windows",
       "operatingsystemrelease": [
         "2012",
-        "2012 R2"
+        "2012 R2",
+        "2016",
+        "2019"
       ]
     },
     {


### PR DESCRIPTION
Thanks for writing this module -- It has saved me a bunch of time. However, I needed to be able to install Filebeat on Windows Server Core editions.

Windows Server Core editions do not have a shell as such, as a result calls to the `Shell.Application` COM object fail. 

This PR replaces the unzip method with the native `Expand-Archive` PowerShell cmdlet present in Powershell 5 and higher. The previous method is maintained for backward compatability for Windows Server < 2016 and Windows < 10. 

According to [this page](https://4sysops.com/wiki/differences-between-powershell-versions/) Windows 10 shipped with Powershell 5.0 and Windows Server 2016 shipped with Powershell 5.1. 

