### PR TITLE
Updated Dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 3.0.0"
+      "version_requirement": ">= 1.0.1 < 4.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Modified module dependency to correct warning being thrown when `puppet module list` command is run on puppet master. Changed dependency maximum version for `puppetlabs/powershell` in the `metadata.json` to correct the warnings and invalid module dependencies.
Please note that I used version numbers exceeding the current version of the dependency to account for future module dependency releases.

These are the warnings that I get when I run puppet module list.

```
root@servernode:~# puppet module list
Warning: Module 'puppetlabs-powershell' (v3.0.1) fails to meet some dependencies:
  'pcfens-filebeat' (v4.3.1) requires 'puppetlabs-powershell' (>= 1.0.1 < 3.0.0)

/etc/puppetlabs/code/environments/production/modules
├── puppetlabs-powershell (v3.0.1)  invalid
```

This pull request fixes these warnings.