### PR TITLE
notify the service to restart when config files are purged.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,6 +125,7 @@ class filebeat::config {
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
         force   => true,
+        notify  => Service['filebeat'],
       }
     } # end Linux
 
@@ -155,6 +156,7 @@ class filebeat::config {
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
         force   => true,
+        notify  => Service['filebeat'],
       }
     } # end FreeBSD
 
@@ -188,6 +190,7 @@ class filebeat::config {
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
         force   => true,
+        notify  => Service['filebeat'],
       }
     } # end OpenBSD
 


### PR DESCRIPTION
This PR addresses an issue of the service needing to be restarted after the configuration dir has been purged.  Otherwise configuration files are purged, and the service is never restarted to pick up the new state of configs.