### PR TITLE
Extended the filebeat::input class to allow using the tcp and udp plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ to fully understand what these parameters do.
     [See above](#json-logs). (default: {})
   - `multiline`: [Hash] Options that control how Filebeat handles log messages that span multiple lines.
     [See above](#multiline-logs). (default: {})
+  - `host`: [String] Host and port used to read events for TCP or UDP plugin (default: localhost:9000)
+  - `max_message_size`: [String] The maximum size of the message received over TCP or UDP (default: undef)
 
 ## Limitations
 This module doesn't load the [elasticsearch index template](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html#filebeat-template) into elasticsearch (required when shipping

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -49,6 +49,8 @@ define filebeat::input (
   Optional[String] $pipeline               = undef,
   Array $processors                        = [],
   Boolean $pure_array                      = false,
+  String $host                             = 'localhost:9000',
+  Optional[String] $max_message_size       = undef,
 ) {
 
   $input_template = $filebeat::major_version ? {

--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -16,7 +16,12 @@
     - <%= tag %>
     <%- end -%>
   <%- end -%>
-  <%- if @input_type == 'docker' -%>
+  <%- if @input_type =~ /(tcp|udp)/ -%>
+  host: <%= @host %>
+  <%- if @max_message_size -%>
+  max_message_size: <%= @max_message_size %>
+  <%- end -%>
+  <%- elsif @input_type == 'docker' -%>
   containers:
     ids:
     <%- @containers_ids.each do |id| -%>


### PR DESCRIPTION
This PR extends the input.yml template and adds the ability to configure tcp and udp plugins.  I tried to make this as simple as possible. 