### PR TITLE
Adding extra_validation_options for test config command

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -99,8 +99,8 @@ class filebeat::config {
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
         default => $major_version ? {
-          '5'     => "${filebeat::filebeat_path} -N -configtest -c %",
-          default => "${filebeat::filebeat_path} -c % test config",
+          '5'     => "${filebeat::filebeat_path} ${filebeat::extra_validate_options} -N -configtest -c %",
+          default => "${filebeat::filebeat_path} ${filebeat::extra_validate_options} -c % test config",
         },
       }
 
@@ -132,7 +132,7 @@ class filebeat::config {
     'FreeBSD'   : {
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
-        default => '/usr/local/sbin/filebeat -N -configtest -c %',
+        default => '/usr/local/sbin/filebeat ${filebeat::extra_validate_options} -N -configtest -c %',
       }
 
       file {'filebeat.yml':
@@ -164,8 +164,8 @@ class filebeat::config {
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
         default => $major_version ? {
-          '5'     => "${filebeat::filebeat_path} -N -configtest -c %",
-          default => "${filebeat::filebeat_path} -c % test config",
+          '5'     => "${filebeat::filebeat_path} ${filebeat::extra_validate_options} -N -configtest -c %",
+          default => "${filebeat::filebeat_path} ${filebeat::extra_validate_options} -c % test config",
         },
       }
 
@@ -201,8 +201,8 @@ class filebeat::config {
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
         default => $major_version ? {
-          '7'     => "\"${filebeat_path}\" test config -c \"%\"",
-          default => "\"${filebeat_path}\" -N -configtest -c \"%\"",
+          '7'     => "\"${filebeat_path}\" ${filebeat::extra_validate_options} test config -c \"%\"",
+          default => "\"${filebeat_path}\" ${filebeat::extra_validate_options} -N -configtest -c \"%\"",
         }
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class filebeat (
   Optional[String] $systemd_beat_log_opts_override                    = undef,
   String $systemd_beat_log_opts_template                              = $filebeat::params::systemd_beat_log_opts_template,
   String $systemd_override_dir                                        = $filebeat::params::systemd_override_dir,
+  Optional[String] $extra_validate_options                            = undef,
 
 ) inherits filebeat::params {
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -24,9 +24,9 @@ describe 'filebeat::config' do
 
             case major_version
             when 5
-              "#{path} -N -configtest -c %"
+              "#{path}  -N -configtest -c %"
             else
-              "#{path} -c % test config"
+              "#{path}  -c % test config"
             end
           end
 
@@ -45,6 +45,12 @@ describe 'filebeat::config' do
                 require: 'File[filebeat-config-dir]',
               )
             }
+            context 'with added extra_validate_options parameter' do
+              let(:pre_condition) { "class { 'filebeat': major_version => '#{major_version}', extra_validate_options => '--foo'}" }
+              it {
+                is_expected.to contain_file('filebeat.yml').with_validate_cmd(/filebeat --foo/)
+              }
+            end
 
             it {
               is_expected.to contain_file('filebeat-config-dir').with(


### PR DESCRIPTION
Allows for extra options to be passed to the flebeat test config command. This allows support of keystore variables as passwords by passing a --path.data allowing the validation command to find the filebeat keystore and potentially other validation options.