### PR TITLE
Resolves pcfens#266

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Installs and configures filebeat.
 - `purge_conf_dir`: [Boolean] Should files in the input configuration directory not managed by puppet be automatically purged
 - `enable_conf_modules`: [Boolean] Should filebeat.config.modules be enabled
 - `modules_dir`: [String] The directory where module configurations should be defined (default: /etc/filebeat/modules.d)
+- `cloud`: [Hash] Will be converted to YAML for the optional cloud.id and cloud.auth of the configuration (see documentation, and above)
 - `outputs`: [Hash] Will be converted to YAML for the required outputs section of the configuration (see documentation, and above)
 - `shipper`: [Hash] Will be converted to YAML to create the optional shipper section of the filebeat config (see documentation)
 - `logging`: [Hash] Will be converted to YAML to create the optional logging section of the filebeat config (see documentation)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class filebeat::config {
         'modules'           => $filebeat::modules,
       },
       'http'              => $filebeat::http,
+      'cloud'             => $filebeat::cloud,
       'output'            => $filebeat::outputs,
       'shipper'           => $filebeat::shipper,
       'logging'           => $filebeat::logging,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@
 # @param config_file_mode [String] The unix permissions mode set on configuration files (default: 0644)
 # @param purge_conf_dir [Boolean] Should files in the input configuration directory not managed by puppet be automatically purged
 # @param http [Hash] A hash of the http section of configuration
+# @param cloud [Hash] Will be converted to YAML for the optional cloud of the configuration (see documentation, and above)
 # @param outputs [Hash] Will be converted to YAML for the required outputs section of the configuration (see documentation, and above)
 # @param shipper [Hash] Will be converted to YAML to create the optional shipper section of the filebeat config (see documentation)
 # @param logging [Hash] Will be converted to YAML to create the optional logging section of the filebeat config (see documentation)
@@ -73,6 +74,7 @@ class filebeat (
   String  $modules_dir                                                = $filebeat::params::modules_dir,
   Boolean $enable_conf_modules                                        = $filebeat::params::enable_conf_modules,
   Hash    $http                                                       = $filebeat::params::http,
+  Hash    $cloud                                                      = $filebeat::params::cloud,
   Hash    $outputs                                                    = $filebeat::params::outputs,
   Hash    $shipper                                                    = $filebeat::params::shipper,
   Hash    $logging                                                    = $filebeat::params::logging,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class filebeat::params {
   $fields                   = {}
   $fields_under_root        = false
   $http                     = {}
+  $cloud                    = {}
   $outputs                  = {}
   $shipper                  = {}
   $logging                  = {}


### PR DESCRIPTION
initial commit of filebeat::cloud hash that allows cloud.id and cloud.auth in the filebeat.yml for major version 6