### PR TITLE
Updated Module Dependencies in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 3.0.0"
+      "version_requirement": ">= 1.0.1 < 4.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 4.0.0"
+      "version_requirement": ">= 1.0.1 < 5.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
I updated the dependency version range in the metadata.json file of puppetlabs/powershell to include the latest version. This fixes the following warnings when the `puppet module list` command is run. 

```
Warning: Module 'puppetlabs-powershell' (v4.0.0) fails to meet some dependencies:
  'pcfens-filebeat' (v4.7.0) requires 'puppetlabs-powershell' (>= 1.0.1 < 4.0.0)
```