### PR TITLE
Fix syntax error in input.yml.erb

### DIFF
--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -189,8 +189,8 @@
   close_timeout: <%= @close_timeout %>
   <%- end -%>
   <%- end -%>
-  <%- # Everything below this can be applied to any input. %>
-  <%- # https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#configuration-general %>
+  <%- # Everything below this can be applied to any input. -%>
+  <%- # https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#configuration-general -%>
   <%- if @fields.length > 0 -%>
   fields:
     <%- @fields.each_pair do |k, v| -%>


### PR DESCRIPTION
With puppet 6.7.2, the following error happened :

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Internal Server Error: org.jruby.exceptions.SyntaxError: (SyntaxError) /etc/puppetlabs/code/environments/production/modules/filebeat/templates/input.yml.erb:193: syntax error, unexpected ')'
);  # https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#configuration-general ; _erbout.<<(-"\n"

Removing the line breaks after the comments seems to fix it.