### PR TITLE
adding autodiscovery to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Installs and configures filebeat.
 - `cloud`: [Hash] Will be converted to YAML for the optional cloud.id and cloud.auth of the configuration (see documentation, and above)
 - `outputs`: [Hash] Will be converted to YAML for the required outputs section of the configuration (see documentation, and above)
 - `shipper`: [Hash] Will be converted to YAML to create the optional shipper section of the filebeat config (see documentation)
+- `autodiscover`: [Hash] Will be converted to YAML for the optional autodiscover section of the configuration (see documentation, and above)`
 - `logging`: [Hash] Will be converted to YAML to create the optional logging section of the filebeat config (see documentation)
 - `systemd_beat_log_opts_override`: [String] Will overide the default `BEAT_LOG_OPTS=-e`. Required if using `logging` hash on systems running with systemd. required: Puppet 6.1+, Filebeat 7+,
 - `modules`: [Array] Will be converted to YAML to create the optional modules section of the filebeat config (see documentation)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,6 +42,7 @@ class filebeat::config {
       'output'            => $filebeat::outputs,
       'shipper'           => $filebeat::shipper,
       'logging'           => $filebeat::logging,
+      'autodiscover'      => $filebeat::autodiscover,
       'runoptions'        => $filebeat::run_options,
       'processors'        => $filebeat::processors,
       'monitoring'        => $filebeat::monitoring,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@
 # proxy_address [String] Proxy server to use for downloading files
 # @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
 # @param extra_validate_options [String] Extra command line options to pass to the configuration validation command
+# @param autodiscover [Hash] Will be converted to YAML for the optional autodiscover section of the configuration (see documentation, and above)
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
@@ -106,6 +107,7 @@ class filebeat (
   String $systemd_beat_log_opts_template                              = $filebeat::params::systemd_beat_log_opts_template,
   String $systemd_override_dir                                        = $filebeat::params::systemd_override_dir,
   Optional[String] $extra_validate_options                            = undef,
+  Hash $autodiscover                                                  = $filebeat::params::autodiscover,
 
 ) inherits filebeat::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class filebeat::params {
   $outputs                  = {}
   $shipper                  = {}
   $logging                  = {}
+  $autodiscover             = {}
   $run_options              = {}
   $modules                  = []
   $kernel_fail_message      = "${::kernel} is not supported by filebeat."


### PR DESCRIPTION
adds support for defining autodiscovery configuration addressing https://github.com/pcfens/puppet-filebeat/issues/178