### PR TITLE
close_timeout can also be defined as string. f.e: '5m' or '2h':

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -37,7 +37,7 @@ define filebeat::input (
   Boolean $close_eof                       = false,
   Variant[String, Integer] $clean_inactive = 0,
   Boolean $clean_removed                   = true,
-  Integer $close_timeout                   = 0,
+  Variant[Integer,String] $close_timeout   = 0,
   Boolean $force_close_files               = false,
   Array[String] $include_lines             = [],
   Array[String] $exclude_lines             = [],


### PR DESCRIPTION
fixes https://github.com/pcfens/puppet-filebeat/issues/273