### PR TITLE
Have a option to not manage the installtion of the package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@
 #
 # @summary Set a bunch of default parameters
 class filebeat::params {
+  $manage_package           = true
   $service_ensure           = running
   $service_enable           = true
   $spool_size               = 2048


### PR DESCRIPTION
I would like to have a parameter to not manage the package.
Use case in my example is on Windows where I want to install filebeat from a internal chocolatey repo (with the 'regular' package resource).
