### PR TITLE
This commit adds syslog support to configuration

### DIFF
--- a/templates/filestream.yml.erb
+++ b/templates/filestream.yml.erb
@@ -4,6 +4,10 @@
 ---
 - type: <%= @input_type %>
   id: <%= @name %>
+  <%- if @input_type == 'syslog' -%>
+  protocol.<%= @syslog_protocol %>:
+    host: <%= @syslog_host %>
+  <%- end -%>
   paths:
   <%- @paths.each do |log_path| -%>
   - <%= log_path %>


### PR DESCRIPTION
In filestream.yml when syslog is set as input_type
several extra configuration has to be set. The
template is adjusted for this.