### PR TITLE
Adapt filebeat to allow filestream as input

### DIFF
--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -172,10 +172,18 @@
   #symlinks: false
 
   <%- if @backoff -%>
+    <%- if @input_type == 'filestream' %>
+  backoff.init: <%= @backoff %>
+    <%- else -%>
   backoff: <%= @backoff %>
+    <%- end -%>
   <%- end -%>
   <%- if @max_backoff -%>
+    <% if @input_type == 'filestream' %>
+  backoff.max: <%= @max_backoff %>
+    <%- else -%>
   max_backoff: <%= @max_backoff %>
+    <%- end -%>
   <%- end -%>
   <%- if @backoff_factor -%>
   backoff_factor: <%= @backoff_factor %>


### PR DESCRIPTION
Using `filestream` (which is the default for inputs from: https://github.com/pcfens/puppet-filebeat/blob/master/manifests/params.pp#L173) was making filebeat fail to start with:

```
Exiting: Failed to start crawler: creating input reloader failed: required 'object', but found 'string' in field '0.backoff' (source:'/etc/filebeat/conf.d/apache-access.yml')
```

This PR changes backoff -> backoff.init and backoff_max -> backoff.max as indicated in: https://www.elastic.co/guide/en/beats/filebeat/current/_step_3_use_new_option_names.html. It's not the only option that would probably needed to be changed, but it was really the option that was making filebeat fail to start at least in my case (I'm using filebeat 8.4.2)