### PR TITLE
feat: Move file exclusion key for new versions

### DIFF
--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -54,10 +54,12 @@
     - '<%= exclude_line %>'
     <%- end -%>
   <%- end -%>
-  <%- if @exclude_files.length > 0 -%>
+  <%- if @input_type != 'filestream' -%>
+    <%- if @exclude_files.length > 0 -%>
   exclude_files:
-    <%- @exclude_files.each do |exclude_file| -%>
+      <%- @exclude_files.each do |exclude_file| -%>
     - <%= exclude_file %>
+      <%- end -%>
     <%- end -%>
   <%- end -%>
   <%- if @ignore_older -%>
@@ -66,11 +68,19 @@
   <%- if @doc_type -%>
   document_type: <%= @doc_type %>
   <%- end -%>
-<%- if @scan_frequency -%>
+<%- if @scan_frequency or @exclude_files -%>
   <%- if @input_type == 'filestream' -%>
   prospector:
      scanner:
+        <%- if @scan_frequency -%>
         check_interval: <%= @scan_frequency %>
+        <%- end -%>
+        <%- if @exclude_files.length > 0 -%>
+        exclude_files:
+          <%- @exclude_files.each do |exclude_file| -%>
+        - <%= exclude_file %>
+          <%- end -%>
+        <%- end -%>
   <%- else -%>
   scan_frequency: <%= @scan_frequency %>
   <%- end -%>


### PR DESCRIPTION
The log input is deprecated and should be replace by filestream instead.

The new filestream have to use the prospector.scanner key to settup the file exclusion key.

https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html

Tested with and without the file exclusion. 

Signed-off-by: Julien Godin <julien.godin@camptocamp.com>