### PR TITLE
Add missing options to JSON decoding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ as documented in the filebeat [configuration documentation](https://www.elastic.
 #### JSON Logs
 
 Filebeat inputs (versions >= 5.0) can natively decode JSON objects if they are stored one per line. The `json`
-parameter accepts a hash containing `message_key`, `keys_under_root`, `overwrite_keys`, and `add_error_key`
-as documented in the filebeat [configuration documentation](https://www.elastic.co/guide/en/beats/filebeat/5.5/configuration-filebeat-options.html#config-json).
+parameter accepts a hash containing `message_key`, `keys_under_root`, `overwrite_keys`, and `add_error_key`.
+
+Depending on the version, `expand_keys`, `document_id` and `ignore_decoding_error` may be supported as well.
+
+See the filebeat [configuration documentation](https://www.elastic.co/guide/en/beats/filebeat/7.11/filebeat-input-log.html#filebeat-input-log-config-json) for details.
 
 ### Inputs in Hiera
 

--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -141,11 +141,32 @@
       overwrite_keys: <%= @json['overwrite_keys'] %>
       <%- end -%>
 
+      # If this setting is enabled, Filebeat will recursively de-dot keys in the decoded JSON,
+      # and expand them into a hierarchical object structure. For example, {"a.b.c": 123}
+      # would be expanded into {"a":{"b":{"c":123}}}. This setting should be enabled when
+      # the input is produced by an ECS logger.
+      <%- if @json['expand_keys'] != nil -%>
+      expand_keys: <%= @json['expand_keys'] %>
+      <%- end -%>
+
       # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       <%- if @json['add_error_key'] != nil -%>
       add_error_key: <%= @json['add_error_key'] %>
+      <%- end -%>
+
+      # Optional configuration setting that specifies the JSON key to set the document id.
+      # If configured, the field will be removed from the original json document and
+      # stored in @metadata._id
+      <%- if @json['document_id'] != nil -%>
+      document_id: <%= @json['document_id'] %>
+      <%- end -%>
+
+      # An optional configuration setting that specifies if JSON decoding errors should
+      # be logged or not. If set to true, errors will not be logged. The default is false.
+      <%- if @json['ignore_decoding_error'] != nil -%>
+      ignore_decoding_error: <%= @json['ignore_decoding_error'] %>
       <%- end -%>
   <%- end -%>
   <%- if @multiline.length > 0 -%>

--- a/templates/prospector.yml.erb
+++ b/templates/prospector.yml.erb
@@ -98,6 +98,12 @@ filebeat:
           <%- if @json['add_error_key'] != nil -%>
           add_error_key: <%= @json['add_error_key'] %>
           <%- end -%>
+
+          # An optional configuration setting that specifies if JSON decoding errors should
+          # be logged or not. If set to true, errors will not be logged. The default is false.
+          <%- if @json['ignore_decoding_error'] != nil -%>
+          ignore_decoding_error: <%= @json['ignore_decoding_error'] %>
+          <%- end -%>
       <%- end -%>
 
       <%- if @multiline.length > 0 -%>


### PR DESCRIPTION
Hello,

this PR adds `expand_keys`, `document_id` and `ignore_decoding_error` options for JSON decoding.

For completeness I've added `ignore_decoding_error` to `templates/prospector.yml.erb`, as this option was already available before version 7. The other two were added in 7.5 and 7.11 respectively, so I've added those to `templates/input.yml.erb` only.

These options exist with the same names in the `ndjson`-Parser for filestream inputs. While this PR does not fix #323, it shouldn't cause any additional issues in that regard, either.

If this makes it into a release soon, I'd be super happy, but no worries if not.

Cheers,
antiz