### PR TITLE
fix install on windows 2012

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -40,7 +40,8 @@ class filebeat::install::windows {
   # Core editions of Windows Server do not have a shell as such, so use the Shell.Application COM object doesn't work.
   # Expand-Archive is a native powershell cmdlet which ships with Powershell 5, which in turn ships with Windows 10 and 
   # Windows Server 2016 and newer.
-  if ((versioncmp($facts['os']['release']['full'], '2016') >= 0) or (versioncmp($facts['os']['release']['full'], '10') >= 0)) {
+  if ( (versioncmp($facts['os']['release']['full'], '2016') >= 0)
+    or (versioncmp($facts['os']['release']['full'], '2000') < 0 and versioncmp($facts['os']['release']['full'], '10') >= 0) ) {
     $unzip_command = "Expand-Archive ${zip_file} \"${filebeat::install_dir}\""
   }
   else {


### PR DESCRIPTION
# Description
The PR #316 broke support for older windows versions (ex: Windows 2012).

This PR fixes the versioncmp to keep the compatibility with Windows 2000/2012 (without removing support for Windows 2016+ and Windows 10+ versions)