### PR TITLE
Default filebeat_version fact to nil if filebeat is not installed

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -30,6 +30,6 @@ Facter.add('filebeat_version') do
     end
   end
   setcode do
-    filebeat_version.nil? ? false : %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1]
+    %r{^filebeat version ([^\s]+)?}.match(filebeat_version)[1] rescue nil
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,7 +102,7 @@ class filebeat::config {
     }
   }
 
-  if 'filebeat_version' in $facts and $facts['filebeat_version'] != false {
+  if $facts['filebeat_version'] {
     $skip_validation = versioncmp($facts['filebeat_version'], $filebeat::major_version) ? {
       -1      => true,
       default => false,

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -58,7 +58,7 @@ define filebeat::input (
   Optional[String] $index                  = undef,
   Boolean $publisher_pipeline_disable_host = false,
 ) {
-  if 'filebeat_version' in $facts and $facts['filebeat_version'] != false {
+  if $facts['filebeat_version'] {
     if versioncmp($facts['filebeat_version'], '6') > 0 {
       $input_template = 'input.yml.erb'
     } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,7 +171,7 @@ class filebeat::params {
     }
   }
 
-  if 'filebeat_version' in $facts and $facts['filebeat_version'] != false {
+  if $facts['filebeat_version'] {
     # filestream input type added in 7.10, deprecated in 7.16
     if versioncmp($facts['filebeat_version'], '7.10') > 0 {
       $default_input_type = 'filestream'

--- a/spec/unit/facter/filebeat_version_spec.rb
+++ b/spec/unit/facter/filebeat_version_spec.rb
@@ -28,8 +28,8 @@ describe 'filebeat_version' do
       File.stubs(:exist?)
       File.expects(:exist?).with('c:\Program Files\Filebeat\filebeat.exe').returns false
     end
-    it 'returns false' do
-      expect(Facter.fact(:filebeat_version).value).to eq(false)
+    it 'returns nil' do
+      expect(Facter.fact(:filebeat_version).value).to eq(nil)
     end
   end
 end

--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -290,7 +290,7 @@
     <%- end -%>
   <%- end -%>
   fields_under_root: <%= @fields_under_root %>
-  <%- unless @facts['filebeat_version'] == false -%>
+  <%- if @facts['filebeat_version'] -%>
     <%- if scope.function_versioncmp([@facts['filebeat_version'], '7.5']) > 0 -%>
       <%- if @index -%>
   index: <%= @index %>


### PR DESCRIPTION
I think the default for *_version facts is `nil`, if the software is not available ( eg. https://github.com/voxpupuli/puppet-php/blob/master/lib/facter/phpversion.rb). The current implementation, setting `filebeat_version` to `false` breaks spec tests for modules that include the filebeat class (a profiles module for example). This is caused by the explicit `false` value for the fact, as the normal fact resolution is not performed during a spec test. 
Functionally, `false` behaves the same as the `nil` value, so nothing really changes by moving the value to `nil` if the software is not installed.

