### PR TITLE
Cover case when config file is in different location than binary

### DIFF
--- a/lib/facter/filebeat_version.rb
+++ b/lib/facter/filebeat_version.rb
@@ -3,29 +3,29 @@ Facter.add('filebeat_version') do
   confine 'kernel' => ['FreeBSD', 'OpenBSD', 'Linux', 'Windows', 'SunOS']
   if File.executable?('/usr/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat version')
-    if filebeat_version.empty?
+    if filebeat_version.empty? or filebeat_version.include? 'error'
       filebeat_version = Facter::Util::Resolution.exec('/usr/bin/filebeat --version')
     end
   elsif File.executable?('/usr/local/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat version')
-    if filebeat_version.empty?
+    if filebeat_version.empty? or filebeat_version.include? 'error'
       filebeat_version = Facter::Util::Resolution.exec('/usr/local/bin/filebeat --version')
     end
   elsif File.executable?('/opt/local/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/opt/local/bin/filebeat version')
-    if filebeat_version.empty?
+    if filebeat_version.empty? or filebeat_version.include? 'error'
       filebeat_version = Facter::Util::Resolution.exec('/opt/local/bin/filebeat --version')
     end
   elsif File.executable?('/usr/share/filebeat/bin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/share/filebeat/bin/filebeat --version')
   elsif File.executable?('/usr/local/sbin/filebeat')
     filebeat_version = Facter::Util::Resolution.exec('/usr/local/sbin/filebeat version')
-    if filebeat_version.empty?
+    if filebeat_version.empty? or filebeat_version.include? 'error'
       filebeat_version = Facter::Util::Resolution.exec('/usr/local/sbin/filebeat --version')
     end
   elsif File.exist?('c:\Program Files\Filebeat\filebeat.exe')
     filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" version')
-    if filebeat_version.empty?
+    if filebeat_version.empty? or filebeat_version.include? 'error'
       filebeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Filebeat\filebeat.exe" --version')
     end
   end


### PR DESCRIPTION
Check if result of exec contains "error". This covers cases when filebeat config is not in the same directory and result of the exec is not empty, but rather `Loading config file error: Failed to read /usr/bin/filebeat.yml: open /usr/bin/filebeat.yml: no such file or directory. Exiting.`  which further cannot be parsed as a valid version.

The case:
```
# systemctl status filebeat.service
● filebeat.service - filebeat
   Loaded: loaded (/usr/lib/systemd/system/filebeat.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2023-04-05 13:18:33 CEST; 9 months 20 days ago
     Docs: https://www.elastic.co/guide/en/beats/filebeat/current/index.html
 Main PID: 751 (filebeat)
   CGroup: /system.slice/filebeat.service
           └─751 /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
```

The result without fix:
```
# facter -p filebeat_version --trace
2024-01-25 06:03:37.224036 ERROR puppetlabs.facter - error while resolving custom fact "filebeat_version": undefined method `[]' for nil:NilClass
backtrace:
/opt/puppetlabs/puppet/cache/lib/facter/filebeat_version.rb:34:in `block (2 levels) in <top (required)>'
```

The result with fix:
```
# facter -p filebeat_version --trace
1.3.1
```
