### PR TITLE
Implement filebeat modules

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -143,6 +143,19 @@ class filebeat::config {
         force   => true,
         notify  => Service['filebeat'],
       }
+
+      file { 'filebeat-modules-dir':
+        ensure  => $filebeat::directory_ensure,
+        path    => $filebeat::modules_dir,
+        owner   => $filebeat::config_dir_owner,
+        group   => $filebeat::config_dir_group,
+        mode    => $filebeat::config_dir_mode,
+        recurse => $filebeat::purge_conf_dir,
+        purge   => $filebeat::purge_conf_dir,
+        force   => true,
+        notify  => Service['filebeat'],
+        require => File['filebeat-config-dir'],
+      }
     } # end Linux
 
     'SunOS'   : {
@@ -172,6 +185,18 @@ class filebeat::config {
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
         force   => true,
+      }
+
+      file { 'filebeat-modules-dir':
+        ensure  => $filebeat::directory_ensure,
+        path    => $filebeat::modules_dir,
+        owner   => $filebeat::config_dir_owner,
+        group   => $filebeat::config_dir_group,
+        mode    => $filebeat::config_dir_mode,
+        recurse => $filebeat::purge_conf_dir,
+        purge   => $filebeat::purge_conf_dir,
+        force   => true,
+        require => File['filebeat-config-dir'],
       }
     } # end SunOS
 
@@ -207,6 +232,19 @@ class filebeat::config {
         force   => true,
         notify  => Service['filebeat'],
       }
+
+      file { 'filebeat-modules-dir':
+        ensure  => $filebeat::directory_ensure,
+        path    => $filebeat::modules_dir,
+        owner   => $filebeat::config_dir_owner,
+        group   => $filebeat::config_dir_group,
+        mode    => $filebeat::config_dir_mode,
+        recurse => $filebeat::purge_conf_dir,
+        purge   => $filebeat::purge_conf_dir,
+        force   => true,
+        notify  => Service['filebeat'],
+        require => File['filebeat-config-dir'],
+      }
     } # end FreeBSD
 
     'OpenBSD'   : {
@@ -241,6 +279,19 @@ class filebeat::config {
         force   => true,
         notify  => Service['filebeat'],
       }
+
+      file { 'filebeat-modules-dir':
+        ensure  => $filebeat::directory_ensure,
+        path    => $filebeat::modules_dir,
+        owner   => $filebeat::config_dir_owner,
+        group   => $filebeat::config_dir_group,
+        mode    => $filebeat::config_dir_mode,
+        recurse => $filebeat::purge_conf_dir,
+        purge   => $filebeat::purge_conf_dir,
+        force   => true,
+        notify  => Service['filebeat'],
+        require => File['filebeat-config-dir'],
+      }
     } # end OpenBSD
 
     'Windows' : {
@@ -270,6 +321,15 @@ class filebeat::config {
         recurse => $filebeat::purge_conf_dir,
         purge   => $filebeat::purge_conf_dir,
         force   => true,
+      }
+
+      file { 'filebeat-modules-dir':
+        ensure  => $filebeat::directory_ensure,
+        path    => $filebeat::modules_dir,
+        recurse => $filebeat::purge_conf_dir,
+        purge   => $filebeat::purge_conf_dir,
+        force   => true,
+        require => File['filebeat-config-dir'],
       }
     } # end Windows
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -1,0 +1,65 @@
+# filebeat::module
+#
+# @summary Base resource to manage Filebeat modules. Check filebeat::module::* for specific implementations.
+#
+# @example
+#   filebeat::module { 'namevar': 
+#     config => {
+#       'log' => {
+#         'enabled' => true,
+#         'var.paths' => [ '/var/log/*.log' ],
+#       },
+#     },
+#   }
+#
+# @param ensure Present or absent. Default: present.
+# @param config Hash with the module configuration.
+#
+define filebeat::module (
+  Enum['absent', 'present'] $ensure = present,
+  Hash $config = {},
+) {
+  $filebeat_config = [{ 'module' => $name } + $config]
+
+  case $facts['kernel'] {
+    'Linux', 'OpenBSD' : {
+      file { "filebeat-module-${name}":
+        ensure  => $ensure,
+        path    => "${filebeat::modules_dir}/${name}.yml",
+        owner   => 'root',
+        group   => '0',
+        mode    => $filebeat::config_file_mode,
+        content => template("${module_name}/pure_hash.yml.erb"),
+        notify  => Service['filebeat'],
+        before  => File['filebeat.yml'],
+      }
+    }
+
+    'FreeBSD' : {
+      file { "filebeat-module-${name}":
+        ensure  => $ensure,
+        path    => "${filebeat::modules_dir}/${name}.yml",
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => $filebeat::config_file_mode,
+        content => template("${module_name}/pure_hash.yml.erb"),
+        notify  => Service['filebeat'],
+        before  => File['filebeat.yml'],
+      }
+    }
+
+    'Windows' : {
+      file { "filebeat-module-${name}":
+        ensure  => $ensure,
+        path    => "${filebeat::modules_dir}/${name}.yml",
+        content => template("${module_name}/pure_hash.yml.erb"),
+        notify  => Service['filebeat'],
+        before  => File['filebeat.yml'],
+      }
+    }
+
+    default : {
+      fail($filebeat::kernel_fail_message)
+    }
+  }
+}

--- a/manifests/module/apache.pp
+++ b/manifests/module/apache.pp
@@ -1,0 +1,49 @@
+# filebeat::module::apache
+#
+# @summary 
+#  This class manages the Filebeat module for Apache HTTP Server.
+#
+# @example
+# class { 'filebeat::module::apache':
+#   access_enabled => true,
+#   access_paths   => [
+#     '/var/log/apache2/access.log',
+#   ],
+#   error_enabled  => true,
+#   error_paths    => [
+#     '/var/log/apache2/error.log',
+#   ],
+# }
+#
+# @param access_enabled
+#  Whether to enable the Apache access log module. Defaults to `false`.
+# @param access_paths
+#   An array of absolute paths to Apache access log files. Defaults to `undef`.
+# @param error_enabled
+#   Whether to enable the Apache error log module. Defaults to `false`.
+# @param error_paths
+#   An array of absolute paths to Apache error log files. Defaults to `undef`.
+#
+class filebeat::module::apache (
+  Boolean $access_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $access_paths = undef,
+  Boolean $error_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $error_paths = undef,
+) {
+  filebeat::module { 'apache':
+    config => {
+      'access' => delete_undef_values(
+        {
+          'enabled'   => $access_enabled,
+          'var.paths' => $access_paths,
+        }
+      ),
+      'error'  => delete_undef_values(
+        {
+          'enabled'   => $error_enabled,
+          'var.paths' => $error_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/auditd.pp
+++ b/manifests/module/auditd.pp
@@ -1,0 +1,33 @@
+# filebeat::module::auditd
+#
+# @summary
+#   This class manages the Filebeat module for auditd.
+#
+# @example
+#   class { 'filebeat::module::auditd':
+#     log_enabled => true,
+#     log_paths   => [
+#       '/var/log/audit/audit.log',
+#     ],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the auditd module.
+# @param log_paths
+#   An array of absolute paths to the auditd log files.
+#
+class filebeat::module::auditd (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+) {
+  filebeat::module { 'auditd':
+    config => {
+      'log' => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/elasticsearch.pp
+++ b/manifests/module/elasticsearch.pp
@@ -1,0 +1,87 @@
+# filebeat::module::elasticsearch
+#
+# @summary
+#   This class manages the filebeat module for elasticsearch.
+#
+# @example
+#   class { 'filebeat::module::elasticsearch':
+#     server_enabled => true,
+#     server_paths   => ['/var/log/elasticsearch/*.log'],
+#     gc_enabled     => true,
+#     gc_paths       => ['/var/log/elasticsearch/gc.log*'],
+#     audit_enabled  => true,
+#     audit_paths    => ['/var/log/elasticsearch/audit.log*'],
+#     deprecation_enabled => true,
+#     deprecation_paths   => ['/var/log/elasticsearch/deprecation.log*'],
+#     slowlog_enabled => true,
+#     slowlog_paths   => ['/var/log/elasticsearch/*_index_search_slowlog.log'],
+#   }
+#
+# @param server_enabled
+#   Boolean to enable or disable the server log. Defaults to false.
+# @param server_paths
+#   Array of absolute paths to the server log files. Defaults to undef.
+# @param gc_enabled
+#   Boolean to enable or disable the garbage collection log. Defaults to false.
+# @param gc_paths
+#   Array of absolute paths to the garbage collection log files. Defaults to undef.
+# @param audit_enabled
+#   Boolean to enable or disable the audit log. Defaults to false.
+# @param audit_paths
+#   Array of absolute paths to the audit log files. Defaults to undef.
+# @param deprecation_enabled
+#   Boolean to enable or disable the deprecation log. Defaults to false.
+# @param deprecation_paths
+#   Array of absolute paths to the deprecation log files. Defaults to undef.
+# @param slowlog_enabled
+#   Boolean to enable or disable the slow log. Defaults to false.
+# @param slowlog_paths
+#   Array of absolute paths to the slow log files. Defaults to undef.
+#
+class filebeat::module::elasticsearch (
+  Boolean $server_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $server_paths = undef,
+  Boolean $gc_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $gc_paths = undef,
+  Boolean $audit_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $audit_paths = undef,
+  Boolean $deprecation_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $deprecation_paths = undef,
+  Boolean $slowlog_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $slowlog_paths = undef,
+) {
+  filebeat::module { 'elasticsearch':
+    config => {
+      'server'      => delete_undef_values(
+        {
+          'enabled'   => $server_enabled,
+          'var.paths' => $server_paths,
+        }
+      ),
+      'gc'          => delete_undef_values(
+        {
+          'enabled'   => $gc_enabled,
+          'var.paths' => $gc_paths,
+        }
+      ),
+      'audit'       => delete_undef_values(
+        {
+          'enabled'   => $audit_enabled,
+          'var.paths' => $audit_paths,
+        }
+      ),
+      'deprecation' => delete_undef_values(
+        {
+          'enabled'   => $deprecation_enabled,
+          'var.paths' => $deprecation_paths,
+        }
+      ),
+      'slowlog'     => delete_undef_values(
+        {
+          'enabled'   => $slowlog_enabled,
+          'var.paths' => $slowlog_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/iptables.pp
+++ b/manifests/module/iptables.pp
@@ -1,0 +1,55 @@
+# filebeat::module::iptables
+#
+# @summary
+#   This class manages the Filebeat iptables module.
+#
+# @example
+#   class { 'filebeat::module::iptables':
+#     log_enabled => true,
+#     log_paths   => [
+#       '/var/log/iptables.log',
+#     ],
+#     log_syslog_host => '0.0.0.0',
+#     log_syslog_port => 9001,
+#     log_tags => [
+#       'iptables',
+#       'forwarded',
+#     ],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the iptables module. Defaults to `false`.
+# @param log_input
+#   The input to use for the iptables logs. file to read from a file, syslog to listen for syslog messages.
+# @param log_paths
+#   An array of absolute paths to the iptables log files.
+# @param log_syslog_host
+#   The interface to bind to for listening for syslog messages.
+# @param log_syslog_port
+#   The port to listen on for syslog messages.
+# @param log_tags
+#   An array of tags to add to the iptables logs.
+#
+class filebeat::module::iptables (
+  Boolean $log_enabled = false,
+  Optional[Enum['file', 'syslog']] $log_input = undef,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+  Optional[Stdlib::Host] $log_syslog_host = undef,
+  Optional[Stdlib::Port] $log_syslog_port = undef,
+  Optional[Array[String[1]]] $log_tags = undef,
+) {
+  filebeat::module { 'iptables':
+    config => {
+      'log' => delete_undef_values(
+        {
+          'enabled'         => $log_enabled,
+          'var.input'       => $log_input,
+          'var.paths'       => $log_paths,
+          'var.syslog_host' => $log_syslog_host,
+          'var.syslog_port' => $log_syslog_port,
+          'var.tags'        => $log_tags,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/kibana.pp
+++ b/manifests/module/kibana.pp
@@ -1,0 +1,45 @@
+# filebeat::module::kibana
+#
+# @summary
+#   This class manages the Filebeat Kibana module.
+#
+# @example
+#   class { 'filebeat::module::kibana':
+#     log_enabled  => true,
+#     log_paths    => ['/var/log/kibana.log'],
+#     audit_enabled => true,
+#     audit_paths   => ['/var/log/kibana-audit.log'],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the Kibana log input. Defaults to `false`.
+# @param log_paths
+#   An array of absolute paths to the Kibana log files.
+# @param audit_enabled
+#   Whether to enable the Kibana audit input. Defaults to `false`.
+# @param audit_paths
+#   An array of absolute paths to the Kibana audit log files.
+#
+class filebeat::module::kibana (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+  Boolean $audit_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $audit_paths = undef,
+) {
+  filebeat::module { 'kibana':
+    config => {
+      'log'   => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+      'audit' => delete_undef_values(
+        {
+          'enabled'   => $audit_enabled,
+          'var.paths' => $audit_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/logstash.pp
+++ b/manifests/module/logstash.pp
@@ -1,0 +1,45 @@
+# filebeat::module::logstash
+#
+# @summary
+#   This class manages the Filebeat Logstash module.
+#
+# @example
+#   class { 'filebeat::module::logstash':
+#     log_enabled     => true,
+#     log_paths       => ['/var/log/logstash/logstash-plain.log'],
+#     slowlog_enabled => true,
+#     slowlog_paths   => ['/var/log/logstash/logstash-slowlog.log'],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the Logstash module.
+# @param log_paths
+#   An array of paths to the Logstash logs.
+# @param slowlog_enabled
+#   Whether to enable the Logstash slowlog module.
+# @param slowlog_paths
+#   An array of paths to the Logstash slowlogs.
+#
+class filebeat::module::logstash (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+  Boolean $slowlog_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $slowlog_paths = undef,
+) {
+  filebeat::module { 'logstash':
+    config => {
+      'log'     => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+      'slowlog' => delete_undef_values(
+        {
+          'enabled'   => $slowlog_enabled,
+          'var.paths' => $slowlog_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/mysql.pp
+++ b/manifests/module/mysql.pp
@@ -1,0 +1,49 @@
+# filebeat::module::mysql
+#
+# @summary
+#   This class manages the Filebeat module for MySQL.
+#
+# @example
+# class { 'filebeat::module::mysql':
+#   error_enabled => true,
+#   error_paths   => [
+#     '/var/log/mysql/error.log',
+#   ],
+#   slowlog_enabled => true,
+#   slowlog_paths   => [
+#     '/var/log/mysql/slow.log',
+#   ],
+# }
+#
+# @param error_enabled
+#   Whether to enable the MySQL error log module. Defaults to false.
+# @param error_paths
+#   An array of absolute paths to the MySQL error log files. Defaults to undef.
+# @param slowlog_enabled
+#   Whether to enable the MySQL slow log module. Defaults to false.
+# @param slowlog_paths
+#   An array of absolute paths to the MySQL slow log files. Defaults to undef.
+#
+class filebeat::module::mysql (
+  Boolean $error_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $error_paths = undef,
+  Boolean $slowlog_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $slowlog_paths = undef,
+) {
+  filebeat::module { 'mysql':
+    config => {
+      'error'   => delete_undef_values(
+        {
+          'enabled'   => $error_enabled,
+          'var.paths' => $error_paths,
+        }
+      ),
+      'slowlog' => delete_undef_values(
+        {
+          'enabled'   => $slowlog_enabled,
+          'var.paths' => $slowlog_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/nginx.pp
+++ b/manifests/module/nginx.pp
@@ -1,0 +1,65 @@
+# filebeat::module::nginx
+#
+# @summary
+#   This class manages the Filebeat module for Nginx.
+#
+# @example
+#   class { 'filebeat::module::nginx':
+#     access_enabled => true,
+#     access_paths   => [
+#       '/var/log/nginx/access.log*',
+#     ],
+#     error_enabled  => true,
+#     error_paths    => [
+#       '/var/log/nginx/error.log*',
+#     ],
+#     ingress_enabled => true,
+#     ingress_paths   => [
+#       '/var/log/nginx/ingress.log*',
+#     ],
+#   }
+#
+# @param access_enabled
+#   Whether to enable the Nginx access module.
+# @param access_paths
+#   The paths to the Nginx access logs.
+# @param error_enabled
+#   Whether to enable the Nginx error module.
+# @param error_paths
+#   The paths to the Nginx error logs.
+# @param ingress_controller_enabled
+#   Whether to enable the Nginx ingress_controller module.
+# @param ingress_controller_paths
+#   The paths to the Nginx ingress_controller logs.
+#
+class filebeat::module::nginx (
+  Boolean $access_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $access_paths = undef,
+  Boolean $error_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $error_paths = undef,
+  Boolean $ingress_controller_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $ingress_controller_paths = undef,
+) {
+  filebeat::module { 'nginx':
+    config => {
+      'access'             => delete_undef_values(
+        {
+          'enabled'   => $access_enabled,
+          'var.paths' => $access_paths,
+        }
+      ),
+      'error'              => delete_undef_values(
+        {
+          'enabled'   => $error_enabled,
+          'var.paths' => $error_paths,
+        }
+      ),
+      'ingress_controller' => delete_undef_values(
+        {
+          'enabled'   => $ingress_controller_enabled,
+          'var.paths' => $ingress_controller_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/postgresql.pp
+++ b/manifests/module/postgresql.pp
@@ -1,0 +1,33 @@
+# filebeat::module::postgresql
+#
+# @summary
+#   This class manages the Filebeat module for PostgreSQL.
+#
+# @example
+#   class { 'filebeat::module::postgresql':
+#     log_enabled => true,
+#     log_paths   => [
+#       '/var/log/postgresql/*.log',
+#     ],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the PostgreSQL module.
+# @param log_paths
+#   An array of absolute paths to the PostgreSQL log files.
+#
+class filebeat::module::postgresql (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+) {
+  filebeat::module { 'postgresql':
+    config => {
+      'log' => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/rabbitmq.pp
+++ b/manifests/module/rabbitmq.pp
@@ -1,0 +1,31 @@
+# filebeat::module::rabbitmq
+#
+# @summary
+#   This class manages the Filebeat RabbitMQ module.
+#
+# @example
+#   class { 'filebeat::module::rabbitmq':
+#     log_enabled => true,
+#     log_paths   => ['/var/log/rabbitmq/*.log'],
+#   }
+#
+# @param log_enabled
+#   Whether to enable the RabbitMQ module.
+# @param log_paths
+#   An array of paths to the RabbitMQ log files.
+#
+class filebeat::module::rabbitmq (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+) {
+  filebeat::module { 'rabbitmq':
+    config => {
+      'log' => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/redis.pp
+++ b/manifests/module/redis.pp
@@ -1,0 +1,50 @@
+# filebeat::module::redis
+#
+# @summary
+#   This class manages the Filebeat Redis module.
+#
+# @example
+#   class { 'filebeat::module::redis':
+#     log_enabled      => true,
+#     log_paths        => ['/var/log/redis/redis-server.log'],
+#     slowlog_enabled  => true,
+#     slowlog_hosts    => ['localhost:6379'],
+#     slowlog_password => 'password',
+#   }
+#
+# @param log_enabled
+#   Whether to enable the Redis log input. Defaults to `false`.
+# @param log_paths
+#   The paths to the Redis log files. Defaults to `undef`.
+# @param slowlog_enabled
+#   Whether to enable the Redis slowlog input. Defaults to `false`.
+# @param slowlog_hosts
+#   The Redis hosts to connect to. Defaults to `undef`.
+# @param slowlog_password
+#   The password to use when connecting to Redis. Defaults to `undef`.
+#
+class filebeat::module::redis (
+  Boolean $log_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $log_paths = undef,
+  Boolean $slowlog_enabled = false,
+  Optional[Array[String[1]]] $slowlog_hosts = undef,
+  Optional[String[1]] $slowlog_password = undef,
+) {
+  filebeat::module { 'redis':
+    config => {
+      'log'     => delete_undef_values(
+        {
+          'enabled'   => $log_enabled,
+          'var.paths' => $log_paths,
+        }
+      ),
+      'slowlog' => delete_undef_values(
+        {
+          'enabled'      => $slowlog_enabled,
+          'var.hosts'    => $slowlog_hosts,
+          'var.password' => $slowlog_password,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/sophos.pp
+++ b/manifests/module/sophos.pp
@@ -1,0 +1,86 @@
+# filebeat::module::sophos
+#
+# @summary
+#   This class manages the Filebeat Sophos module.
+#
+# @example
+#   class { 'filebeat::module::sophos':
+#     xg_enabled => true,
+#     xg_input => 'udp',
+#     xg_syslog_host => '0.0.0.0',
+#     xg_syslog_port => 514,
+#     xg_host_name => 'sophos-xg',
+#   }
+#
+# @param xg_enabled
+#   Whether to enable the Sophos XG module.
+# @param xg_paths
+#   An array of paths to the Sophos XG logs.
+# @param xg_input
+#   The input type for the Sophos XG module. tcp or udp for syslog input, file for log files.
+# @param xg_syslog_host
+#   Interface to listen to for syslog input.
+# @param xg_syslog_port
+#   Port to listen on for syslog input.
+# @param xg_host_name
+#   Host name / Observer name, since SophosXG does not provide this in the syslog file. 
+# @param utm_enabled
+#   Whether to enable the Sophos UTM module.
+# @param utm_paths
+#   An array of paths to the Sophos UTM logs.
+# @param utm_input
+#   The input type for the Sophos UTM module. tcp or udp for syslog input, file for log files.
+# @param utm_syslog_host
+#   Interface to listen to for syslog input.
+# @param utm_syslog_port
+#   Port to listen on for syslog input.
+# @param utm_tz_offset
+#   Timezone offset. If the logs are in a different timezone than the Filebeat host, set this to the timezone offset.
+# @param utm_rsa_fields
+#   Flag to control whether non-ECS fields are added to the event.
+# @param utm_keep_raw_fields
+#   Flag to control the addition of the raw parser fields to the event.
+#
+class filebeat::module::sophos (
+  Boolean $xg_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $xg_paths = undef,
+  Optional[Enum['udp', 'tcp','file']] $xg_input = undef,
+  Optional[Stdlib::Host] $xg_syslog_host = undef,
+  Optional[Stdlib::Port] $xg_syslog_port = undef,
+  Optional[Stdlib::Host] $xg_host_name = undef,
+  Boolean $utm_enabled = false,
+  Optional[Array[Stdlib::Absolutepath]] $utm_paths = undef,
+  Optional[Enum['udp', 'tcp','file']] $utm_input = undef,
+  Optional[Stdlib::Host] $utm_syslog_host = undef,
+  Optional[Stdlib::Port] $utm_syslog_port = undef,
+  Optional[Pattern[/^[-+]\d{2}:\d{2}$/]] $utm_tz_offset = undef,
+  Optional[Boolean] $utm_rsa_fields = undef,
+  Optional[Boolean] $utm_keep_raw_fields = undef,
+) {
+  filebeat::module { 'sophos':
+    config => {
+      'xg' => delete_undef_values(
+        {
+          'enabled' => $xg_enabled,
+          'var.input' => $xg_input,
+          'var.paths' => $xg_paths,
+          'var.syslog_host' => $xg_syslog_host,
+          'var.syslog_port' => $xg_syslog_port,
+          'var.host_name' => $xg_host_name,
+        }
+      ),
+      'utm' => delete_undef_values(
+        {
+          'enabled' => $utm_enabled,
+          'var.input' => $utm_input,
+          'var.paths' => $utm_paths,
+          'var.syslog_host' => $utm_syslog_host,
+          'var.syslog_port' => $utm_syslog_port,
+          'var.tz_offset' => $utm_tz_offset,
+          'var.rsa_fields' => $utm_rsa_fields,
+          'var.keep_raw_fields' => $utm_keep_raw_fields,
+        }
+      ),
+    },
+  }
+}

--- a/manifests/module/system.pp
+++ b/manifests/module/system.pp
@@ -1,0 +1,49 @@
+# filebeat::module::system
+#
+# @summary
+#   This class manages the Filebeat system module.
+#
+# @example
+#   class { 'filebeat::module::system':
+#     syslog_enabled => true,
+#     syslog_paths   => [
+#       '/var/log/syslog',
+#     ],
+#     auth_enabled   => true,
+#     auth_paths     => [
+#       '/var/log/auth.log',
+#     ],
+#   }
+#
+# @param syslog_enabled
+#   A boolean value to enable or disable the syslog module.
+# @param syslog_paths
+#   An optional array of paths to the syslog logs.
+# @param auth_enabled
+#   A boolean value to enable or disable the auth module.
+# @param auth_paths
+#   An optional array of paths to the auth logs.
+#
+class filebeat::module::system (
+  Boolean $syslog_enabled = false,
+  Optional[Array[Stdlib::Unixpath]] $syslog_paths = undef,
+  Boolean $auth_enabled = false,
+  Optional[Array[Stdlib::Unixpath]] $auth_paths = undef,
+) {
+  filebeat::module { 'system':
+    config => {
+      'syslog' => delete_undef_values(
+        {
+          'enabled'   => $syslog_enabled,
+          'var.paths' => $syslog_paths,
+        }
+      ),
+      'auth'   => delete_undef_values(
+        {
+          'enabled'   => $auth_enabled,
+          'var.paths' => $auth_paths,
+        }
+      ),
+    },
+  }
+}

--- a/spec/classes/module/apache_spec.rb
+++ b/spec/classes/module/apache_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::apache' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-apache').with_content(
+      %r{- module: apache\n\s{2}access:\n\s{4}enabled: false\n\s{2}error:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on access and error enabled with paths' do
+    let(:params) do
+      {
+        'access_enabled' => true,
+        'access_paths' => ['/var/log/apache2/access.log', '/var/log/apache2/*-access.log'],
+        'error_enabled' => true,
+        'error_paths' => ['/var/log/apache2/error.log', '/var/log/apache2/*-error.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-apache').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: apache
+  access:
+    enabled: true
+    var.paths:
+    - "/var/log/apache2/access.log"
+    - "/var/log/apache2/*-access.log"
+  error:
+    enabled: true
+    var.paths:
+    - "/var/log/apache2/error.log"
+    - "/var/log/apache2/*-error.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/auditd_spec.rb
+++ b/spec/classes/module/auditd_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::auditd' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-auditd').with_content(
+      %r{- module: auditd\n\s{2}log:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/audit/audit.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-auditd').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: auditd
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/audit/audit.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/elasticsearch_spec.rb
+++ b/spec/classes/module/elasticsearch_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::elasticsearch' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-elasticsearch').with_content(
+      %r{- module: elasticsearch\n\s{2}server:\n\s{4}enabled: false\n\s{2}gc:\n\s{4}enabled: false\n\s{2}audit:\n\s{4}enabled: false\n\s{2}deprecation:\n\s{4}enabled: false\n\s{2}slowlog:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on server,gc,audit,slowlog and deprecation enabled with paths' do
+    let(:params) do
+      {
+        'server_enabled' => true,
+        'server_paths' => ['/var/log/elasticsearch/*.log'],
+        'gc_enabled' => true,
+        'gc_paths' => ['/var/log/elasticsearch/gc.log*'],
+        'audit_enabled' => true,
+        'audit_paths' => ['/var/log/elasticsearch/audit.log'],
+        'slowlog_enabled' => true,
+        'slowlog_paths' => ['/var/log/elasticsearch/*_search_slowlog.log'],
+        'deprecation_enabled' => true,
+        'deprecation_paths' => ['/var/log/elasticsearch/*_deprecation.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-elasticsearch').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: elasticsearch
+  server:
+    enabled: true
+    var.paths:
+    - "/var/log/elasticsearch/*.log"
+  gc:
+    enabled: true
+    var.paths:
+    - "/var/log/elasticsearch/gc.log*"
+  audit:
+    enabled: true
+    var.paths:
+    - "/var/log/elasticsearch/audit.log"
+  deprecation:
+    enabled: true
+    var.paths:
+    - "/var/log/elasticsearch/*_deprecation.log"
+  slowlog:
+    enabled: true
+    var.paths:
+    - "/var/log/elasticsearch/*_search_slowlog.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/iptables_spec.rb
+++ b/spec/classes/module/iptables_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::iptables' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-iptables').with_content(
+      %r{- module: iptables\n\s{2}log:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on iptables logfile' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/ip6tables.log', '/var/log/iptables.log'],
+        'log_input' => 'file',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-iptables').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: iptables
+  log:
+    enabled: true
+    var.input: file
+    var.paths:
+    - "/var/log/ip6tables.log"
+    - "/var/log/iptables.log"
+
+EOS
+    )
+    }
+  end
+
+  context 'on iptables with syslog' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_input' => 'syslog',
+        'log_syslog_host' => '0.0.0.0',
+        'log_syslog_port' => 514,
+        'log_tags' => [
+          "iptables"
+        ]
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-iptables').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: iptables
+  log:
+    enabled: true
+    var.input: syslog
+    var.syslog_host: 0.0.0.0
+    var.syslog_port: 514
+    var.tags:
+    - iptables
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/kibana_spec.rb
+++ b/spec/classes/module/kibana_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::kibana' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-kibana').with_content(
+      %r{- module: kibana\n\s{2}log:\n\s{4}enabled: false\n\s{2}audit:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log and audit enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/kibana.log'],
+        'audit_enabled' => true,
+        'audit_paths' => ['/var/log/kibana-audit.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-kibana').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: kibana
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/kibana.log"
+  audit:
+    enabled: true
+    var.paths:
+    - "/var/log/kibana-audit.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/logstash_spec.rb
+++ b/spec/classes/module/logstash_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::logstash' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-logstash').with_content(
+      %r{- module: logstash\n\s{2}log:\n\s{4}enabled: false\n\s{2}slowlog:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log and slowlog enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/logstash.log'],
+        'slowlog_enabled' => true,
+        'slowlog_paths' => ['/var/log/logstash-slowlog.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-logstash').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: logstash
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/logstash.log"
+  slowlog:
+    enabled: true
+    var.paths:
+    - "/var/log/logstash-slowlog.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/mysql_spec.rb
+++ b/spec/classes/module/mysql_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::mysql' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-mysql').with_content(
+      %r{- module: mysql\n\s{2}error:\n\s{4}enabled: false\n\s{2}slowlog:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on error and slowlog enabled with paths' do
+    let(:params) do
+      {
+        'error_enabled' => true,
+        'error_paths' => ['/var/log/mysql/error.log'],
+        'slowlog_enabled' => true,
+        'slowlog_paths' => ['/var/log/mysql/slowlog.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-mysql').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: mysql
+  error:
+    enabled: true
+    var.paths:
+    - "/var/log/mysql/error.log"
+  slowlog:
+    enabled: true
+    var.paths:
+    - "/var/log/mysql/slowlog.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/nginx_spec.rb
+++ b/spec/classes/module/nginx_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::nginx' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-nginx').with_content(
+      %r{- module: nginx\n\s{2}access:\n\s{4}enabled: false\n\s{2}error:\n\s{4}enabled: false\n\s{2}ingress_controller:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on access, error and ingress_controller enabled with paths' do
+    let(:params) do
+      {
+        'access_enabled' => true,
+        'access_paths' => ['/var/log/nginx/access.log'],
+        'error_enabled' => true,
+        'error_paths' => ['/var/log/nginx/error.log'],
+        'ingress_controller_enabled' => true,
+        'ingress_controller_paths' => ['/var/log/nginx/ingress_controller.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-nginx').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: nginx
+  access:
+    enabled: true
+    var.paths:
+    - "/var/log/nginx/access.log"
+  error:
+    enabled: true
+    var.paths:
+    - "/var/log/nginx/error.log"
+  ingress_controller:
+    enabled: true
+    var.paths:
+    - "/var/log/nginx/ingress_controller.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/postgresql_spec.rb
+++ b/spec/classes/module/postgresql_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::postgresql' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-postgresql').with_content(
+      %r{- module: postgresql\n\s{2}log:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/postgresql.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-postgresql').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: postgresql
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/postgresql.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/rabbitmq_spec.rb
+++ b/spec/classes/module/rabbitmq_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::rabbitmq' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-rabbitmq').with_content(
+      %r{- module: rabbitmq\n\s{2}log:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/rabbitmq.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-rabbitmq').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: rabbitmq
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/rabbitmq.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/redis_spec.rb
+++ b/spec/classes/module/redis_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::redis' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-redis').with_content(
+      %r{- module: redis\n\s{2}log:\n\s{4}enabled: false\n\s{2}slowlog:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log and slowlog enabled with paths' do
+    let(:params) do
+      {
+        'log_enabled' => true,
+        'log_paths' => ['/var/log/redis.log'],
+        'slowlog_enabled' => true,
+        'slowlog_hosts' => ['localhost:6379'],
+        'slowlog_password' => 'password',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-redis').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: redis
+  log:
+    enabled: true
+    var.paths:
+    - "/var/log/redis.log"
+  slowlog:
+    enabled: true
+    var.hosts:
+    - localhost:6379
+    var.password: password
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/sophos_spec.rb
+++ b/spec/classes/module/sophos_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::sophos' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-sophos').with_content(
+      %r{- module: sophos\n\s{2}xg:\n\s{4}enabled: false\n\s{2}utm:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on xg and utm enabled with paths' do
+    let(:params) do
+      {
+        'xg_enabled' => true,
+        'xg_input' => 'file',
+        'xg_paths' => ['/var/log/xg.log'],
+        'utm_enabled' => true,
+        'utm_input' => 'file',
+        'utm_paths' => ['/var/log/utm.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-sophos').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: sophos
+  xg:
+    enabled: true
+    var.input: file
+    var.paths:
+    - "/var/log/xg.log"
+  utm:
+    enabled: true
+    var.input: file
+    var.paths:
+    - "/var/log/utm.log"
+
+EOS
+    )
+    }
+  end
+
+  context 'on xg and utm enabled with syslog input' do
+    let(:params) do
+      {
+        'xg_enabled' => true,
+        'xg_input' => 'udp',
+        'xg_syslog_host' => '0.0.0.0',
+        'xg_syslog_port' => 514,
+        'xg_host_name' => 'sophos-xg',
+        'utm_enabled' => true,
+        'utm_input' => 'tcp',
+        'utm_syslog_host' => '0.0.0.0',
+        'utm_syslog_port' => 515,
+        'utm_tz_offset' => '-07:00',
+        'utm_rsa_fields' => true,
+        'utm_keep_raw_fields' => true,
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-sophos').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: sophos
+  xg:
+    enabled: true
+    var.input: udp
+    var.syslog_host: 0.0.0.0
+    var.syslog_port: 514
+    var.host_name: sophos-xg
+  utm:
+    enabled: true
+    var.input: tcp
+    var.syslog_host: 0.0.0.0
+    var.syslog_port: 515
+    var.tz_offset: "-07:00"
+    var.rsa_fields: true
+    var.keep_raw_fields: true
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/classes/module/system_spec.rb
+++ b/spec/classes/module/system_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module::system' do
+  let :pre_condition do
+    'include ::filebeat'
+  end
+
+  let(:facts) { 
+    {
+      :kernel => 'Linux',
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+      }
+    } 
+  }
+  
+  context 'on default values' do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-system').with_content(
+      %r{- module: system\n\s{2}syslog:\n\s{4}enabled: false\n\s{2}auth:\n\s{4}enabled: false\n\n},
+    )}
+  end
+
+  context 'on log and slowlog enabled with paths' do
+    let(:params) do
+      {
+        'syslog_enabled' => true,
+        'syslog_paths' => ['/var/log/syslog'],
+        'auth_enabled' => true,
+        'auth_paths' => ['/var/log/auth.log'],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_file('filebeat-module-system').with_content(
+        <<-EOS
+### Filebeat configuration managed by Puppet ###
+---
+- module: system
+  syslog:
+    enabled: true
+    var.paths:
+    - "/var/log/syslog"
+  auth:
+    enabled: true
+    var.paths:
+    - "/var/log/auth.log"
+
+EOS
+    )
+    }
+  end
+end

--- a/spec/defines/module_spec.rb
+++ b/spec/defines/module_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'filebeat::module' do
+  let :pre_condition do
+    'class { "filebeat":
+        outputs => {
+          "logstash" => {
+            "hosts" => [
+              "localhost:5044",
+            ],
+          },
+        },
+        inputs => [
+          {
+            "type" => "logs",
+            "paths" => [
+              "/var/log/auth.log",
+              "/var/log/syslog",
+            ],
+          },
+          {
+            "type" => "syslog",
+            "protocol.tcp" => {
+              "host" => "0.0.0.0:514",
+            },
+          },
+        ],
+      }'
+  end
+
+  let(:title) { 'test' }
+  let(:params) do
+    {}
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      if os_facts[:kernel] == 'Linux'
+        it { is_expected.to compile }
+
+        it {
+          is_expected.to contain_file('filebeat-module-test').with(
+            notify: 'Service[filebeat]',
+          )
+          is_expected.to contain_file('filebeat-module-test').with_content(
+            %r{- module: test},
+          )
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

this PR implements the possibility to manage some of the filebeat modules to be configured with this puppet module. The module currently only supports modules by giving the whole array to `filebeat::modules`. It also requires people to know the exact structure that it works.

The new `filebeat::module::*` classes will abstract the structure and also perform correct datatype for each parameter. Beside this it also enables to setup modules based on the really installed services on a host if you define the `filebeat::module::*` in your profile / role files.

e.g. we now can do in our `profile::redis` take care of the redis configuration and also include `filebeat::module::redis` without having to somehow pass it to the `filebeat::modules:` array.

So far i only implemented modules used by us but implementation of the other filebeat modules would be possible and also custom modules will be possible if the module files (pipeline, dashboard etc.) are copied to the correct directory.

Best regards,
Stephan