### PR TITLE
Add configuration for seccomp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -53,6 +53,7 @@ class filebeat::config {
         'processors'        => $filebeat::processors,
         'monitoring'        => $filebeat::monitoring,
         'setup'             => $setup,
+        'seccomp.enabled'   => $filebeat::seccomp_enable,
     })
     # Add the 'xpack' section if supported (version >= 6.1.0) and not undef
     if $filebeat::xpack and versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@
 # @param monitoring [Hash] The monitoring section of the configuration file.
 # @param inputs [Hash] or [Array] Inputs that will be created. Commonly used to create inputs using hiera
 # @param setup [Hash] setup that will be created. Commonly used to create setup using hiera
+# @param seccomp_enable [Boolean] enable or disable seccomp. Default is enabled on Linux.
 # proxy_address [String] Proxy server to use for downloading files
 # @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
 # @param extra_validate_options [String] Extra command line options to pass to the configuration validation command
@@ -114,6 +115,7 @@ class filebeat (
   Optional[Hash]  $monitoring                                         = undef,
   Variant[Hash, Array] $inputs                                        = {},
   Hash    $setup                                                      = {},
+  Boolean $seccomp_enable                                             = $filebeat::params::seccomp_enable,
   Array   $modules                                                    = [],
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address = undef, # lint:ignore:140chars
   Stdlib::Absolutepath $filebeat_path                                 = $filebeat::params::filebeat_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,6 +91,7 @@ class filebeat::params {
       # These parameters are ignored if/until tarball installs are supported in Linux
       $tmp_dir         = '/tmp'
       $install_dir     = undef
+      $seccomp_enable  = true
       case $facts['os']['family'] {
         'RedHat': {
           $service_provider = 'systemd'
@@ -115,6 +116,7 @@ class filebeat::params {
       $service_provider  = undef
       $install_dir       = undef
       $url_arch          = undef
+      $seccomp_enable    = false
     }
 
     'FreeBSD': {
@@ -130,6 +132,7 @@ class filebeat::params {
       $service_provider  = undef
       $install_dir       = undef
       $url_arch          = undef
+      $seccomp_enable    = false
     }
 
     'OpenBSD': {
@@ -140,11 +143,12 @@ class filebeat::params {
       $config_file_group = 'wheel'
       $config_dir_owner  = 'root'
       $config_dir_group  = 'wheel'
-      $modules_dir        = '/etc/filebeat/modules.d'
+      $modules_dir       = '/etc/filebeat/modules.d'
       $tmp_dir           = '/tmp'
       $service_provider  = undef
       $install_dir       = undef
       $url_arch          = undef
+      $seccomp_enable    = false
     }
 
     'Windows' : {
@@ -159,6 +163,7 @@ class filebeat::params {
       $install_dir      = 'C:/Program Files'
       $tmp_dir          = 'C:/Windows/Temp'
       $service_provider = undef
+      $seccomp_enable   = false
       $url_arch         = $facts['os']['architecture'] ? {
         'x86'   => 'x86',
         'x64'   => 'x86_64',


### PR DESCRIPTION
Without this disabled, we get horrific SIGABRT every time the service starts, which is annoying to say the least.

I would deploy this as an empty hash, but I worry about what will happen if the key is set on platforms where seccomp makes little sense. Hope someone can provide some guidance and/or testing.

Details on the extended config:
https://www.elastic.co/guide/en/beats/filebeat/8.12/linux-seccomp.html