### PR TITLE
Update metadata.json dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 < 10.0.0"
+      "version_requirement": ">=2.0.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 6.0.0"
+      "version_requirement": ">= 1.0.1 < 7.0.0"
     },
     {
       "name": "puppet/archive",
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Metadata Dependency ranges are out of date with upstream which causes conflicts when `puppet module install` tries to reconcile versions of these dependencies with other modules. Ranges need to be widened to support the latest available.