### PR TITLE
Fix: install dir on windows

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -305,14 +305,14 @@ define filebeat::input (
     }
 
     'Windows' : {
-      $cmd_install_dir = regsubst($filebeat::install_dir, '/', '', 'G')
-      $filebeat_path = join([$cmd_install_dir, 'Filebeat', 'filebeat.exe'], '')
+      $cmd_install_dir = regsubst($filebeat::install_dir, '/', '\\', 'G')
+      $filebeat_path = join([$cmd_install_dir, 'Filebeat', 'filebeat.exe'], '\\')
 
       $validate_cmd = ($filebeat::disable_config_test or $skip_validation) ? {
         true    => undef,
         default => $facts['filebeat_version'] ? {
-          '5'     => "${filebeat_path} -N -configtest -c %",
-          default => "${filebeat_path} -c ${filebeat::config_file} test config",
+          '5'     => "\"${filebeat_path}\" -N -configtest -c \"%\"",
+          default => "\"${filebeat_path}\" -c \"${filebeat::config_file}\" test config",
         },
       }
 


### PR DESCRIPTION
Hi,

This is a fix on the windows install path to prevent the error below:
`Debug: Executing: 'C:Program FilesFilebeatfilebeat.exe -c C:/Program Files/Filebeat/filebeat.yml test config'
Error: Could not set 'present' on ensure: No such file or directory - CreateProcess (file: /etc/puppetlabs/code/environments/xxxxxxxxxxxxx/modules/filebeat/manifests/input.pp, line: 319)
Error: Could not set 'present' on ensure: No such file or directory - CreateProcess (file: /etc/puppetlabs/code/environments/xxxxxxxxxxxxxxxxx/modules/filebeat/manifests/input.pp, line: 319)
Wrapped exception:
No such file or directory - CreateProcess`

We can clearly see the filebeat binary path is incorrrect `C:Program FilesFilebeatfilebeat.exe` due to the regsubst removing the "/".