### PR TITLE
feat(input): nest symlinks under prospector.scanner for filestream

### DIFF
--- a/templates/input.yml.erb
+++ b/templates/input.yml.erb
@@ -94,7 +94,7 @@
   document_type: <%= @doc_type %>
     <%- end -%>
   <%- end -%>
-  <%- if @scan_frequency or @exclude_files -%>
+  <%- if @scan_frequency or @exclude_files or (@symlinks and @input_type == 'filestream') -%>
     <%- if @input_type == 'filestream' -%>
   prospector:
     scanner:
@@ -106,6 +106,9 @@
         <%- @exclude_files.each do |exclude_file| -%>
       - <%= exclude_file %>
         <%- end -%>
+      <%- end -%>
+      <%- if @symlinks -%>
+      symlinks: <%= @symlinks %>
       <%- end -%>
     <%- else -%>
   scan_frequency: <%= @scan_frequency %>
@@ -121,7 +124,7 @@
   max_bytes: <%= @max_bytes %>
     <%- end -%>
   <%- end -%>
-  <%- if @symlinks -%>
+  <%- if @symlinks and @input_type != 'filestream' -%>
   symlinks: <%= @symlinks %>
   <%- end -%>
   <%- if @close_older -%>
@@ -214,10 +217,6 @@
       <%- end -%>
     <%- end -%>
   tail_files: <%= @tail_files %>
-
-  # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
-  # original for harvesting but will report the symlink name as source.
-  #symlinks: false
 
   <%- if @backoff -%>
     <%- if @input_type == 'filestream' -%>


### PR DESCRIPTION
Previously, symlinks was always rendered as a flat top-level `symlinks: <value>` key regardless of input_type. For filestream inputs, this option actually belongs under the existing `prospector.scanner` block, so it's now emitted there instead. Non-filestream inputs (e.g. log) keep the flat `symlinks` key unchanged.

Remove unused hardcoded symlink comment block.